### PR TITLE
Fix docker environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,12 @@
+# Taken from https://github.com/alexkaratarakis/gitattributes/blob/master/LICENSE.md - Copyright (c) 2015 Alexander Karatarakis
+
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
 * text=auto
 
+#
+# The above will handle all files NOT found below
+#
 # These files are text and should be normalized (Convert crlf => lf)
 *.css           text
 *.df            text
@@ -21,6 +28,7 @@
 *.yml           text
 
 # These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
 *.class         binary
 *.dll           binary
 *.ear           binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+* text=auto
+
+# These files are text and should be normalized (Convert crlf => lf)
+*.css           text
+*.df            text
+*.htm           text
+*.html          text
+*.java          text
+*.js            text
+*.json          text
+*.jsp           text
+*.jspf          text
+*.jspx          text
+*.properties    text
+*.sh            text
+*.tld           text
+*.txt           text
+*.tag           text
+*.tagx          text
+*.xml           text
+*.yml           text
+
+# These files are binary and should be left untouched
+*.class         binary
+*.dll           binary
+*.ear           binary
+*.gif           binary
+*.ico           binary
+*.jar           binary
+*.jpg           binary
+*.jpeg          binary
+*.png           binary
+*.so            binary
+*.war           binary

--- a/docker/README.md
+++ b/docker/README.md
@@ -37,7 +37,7 @@ At this point, you are ready to perform the actual build with the following comm
 
 ```
 docker build --tag vulas-build-img -f docker/Dockerfile --build-arg http_proxy= --build-arg https_proxy=  . 
-docker run -it --rm -v $(pwd):/vulas --env-file ./docker/.env vulas-build-img
+docker run -it --rm -v ${PWD}:/vulas --env-file ./docker/.env vulas-build-img
 ```
 
 In case you are running behind a proxy you need to configure it in the `--build-arg` arguments.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     ports:
       - "8032:5432"
     volumes:
-      - "./data/postgresql:/var/lib/postgresql/data"
+      - vulas-os-postgres-data:/var/lib/postgresql/data
 
   rest-backend:
     container_name: vulas-os-rest-backend
@@ -126,3 +126,6 @@ services:
         - "8092"
     volumes:
       - "./data/rest-lib-utils:/root/"
+  
+volumes:
+  vulas-os-postgres-data:

--- a/docker/rest-backend/run.sh
+++ b/docker/rest-backend/run.sh
@@ -20,4 +20,4 @@ java \
     -Dvulas.jira.pwd=$JIRA_PASSWORD \
     $FLYWAY_OPTS \
     -Dspring.profiles.active=docker \
-	-jar /vulas/vulas-backend.jar
+	-jar /vulas/rest-backend.jar


### PR DESCRIPTION
This PR:
* Fixes the incorrect name of `rest-backend` which broke the docker-compose
* Makes vulas-docker compatible with Windows by:
  * Changing the line endings to LF so that the scripts are runnable by docker
  * Change the volumes of postgres to be named, so that no user conflicts will be present. (https://github.com/docker-library/postgres/issues/435)
  * Add to the docs a cross-platform way of sharing volumes

Tested on Win10 noWSL - Docker version 18.01.0-ce, build 03596f5