### PR TITLE
added migration to drop parent FK in app_dependency

### DIFF
--- a/rest-backend/src/main/resources/db/migration/V20181029.1330__depParentFK.sql
+++ b/rest-backend/src/main/resources/db/migration/V20181029.1330__depParentFK.sql
@@ -1,0 +1,2 @@
+--Dropping FK for performance reasons (exp. on delete)
+alter table app_dependency drop constraint if exists fk3q24nj7pisqslyss56g82t7n4 ;


### PR DESCRIPTION
dropping the foreign key on column parent of table app_dependency to avoid performance issues encountered on deletion of applications.