### PR TITLE
Update LICENSE.txt/Fixes #47

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -222,7 +222,7 @@ Additional Notices: N.a.
 Component: Dependency Finder
 Licensor: Jean Tessier
 Website: https://github.com/jeantessier/dependency-finder
-License: Custom license (https://github.com/jeantessier/dependency-finder/blob/master/license.txt, a copy is included below)
+License: BSD-like (https://github.com/jeantessier/dependency-finder/blob/master/license.txt, a copy is included below)
 Additional Notices: N.a.
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Updates our License in order to reflect what @msohn said in #47.

I propose to replace `Custom License` with `BSD-like` since on the [Readme of the project](https://github.com/jeantessier/dependency-finder/blob/master/README.md#licensing) it is written that its license is `BSD-like`