### PR TITLE
Multi-threading the execution of Vulas plugin goals

### DIFF
--- a/cli-scanner/src/test/java/com/sap/psr/vulas/cli/AbstractGoalTest.java
+++ b/cli-scanner/src/test/java/com/sap/psr/vulas/cli/AbstractGoalTest.java
@@ -1,7 +1,6 @@
 package com.sap.psr.vulas.cli;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.ArrayList;
 
 import org.junit.After;
 import org.junit.Before;
@@ -33,6 +32,9 @@ public class AbstractGoalTest {
 		testSpace = this.buildTestSpace();
 		testApp = this.buildTestApplication();
 		
+		// Clear and set properties
+		this.clearVulasProperties();
+		
 		// App context
 		System.setProperty(CoreConfiguration.APP_CTX_GROUP, testApp.getMvnGroup());
 		System.setProperty(CoreConfiguration.APP_CTX_ARTIF, testApp.getArtifact());
@@ -47,7 +49,17 @@ public class AbstractGoalTest {
 
 	@After
 	public void stop() {
+		this.clearVulasProperties();
 		server.stop();
+	}
+	
+	private void clearVulasProperties() {
+		final ArrayList<String> l = new ArrayList<String>();
+		for(Object k: System.getProperties().keySet())
+			if(k instanceof String && ((String)k).startsWith("vulas."))
+				l.add((String)k);
+		for(String k: l)
+			System.clearProperty(k);
 	}
 
 	protected Tenant buildTestTenant() {
@@ -68,6 +80,6 @@ public class AbstractGoalTest {
 	protected void configureBackendServiceUrl(StubServer _ss) {
 		final StringBuffer b = new StringBuffer();
 		b.append("http://localhost:").append(_ss.getPort()).append("/backend");
-		VulasConfiguration.getGlobal().setProperty(VulasConfiguration.getServiceUrlKey(Service.BACKEND), b.toString());
+		System.setProperty(VulasConfiguration.getServiceUrlKey(Service.BACKEND), b.toString());
 	}
 }

--- a/cli-scanner/src/test/java/com/sap/psr/vulas/cli/VulasCliTest.java
+++ b/cli-scanner/src/test/java/com/sap/psr/vulas/cli/VulasCliTest.java
@@ -148,7 +148,7 @@ public class VulasCliTest extends AbstractGoalTest {
 		verifyHttp(server).times(1, 
 				method(Method.PUT),
 				uri("/backend" + PathBuilder.app(this.testApp)));
-		verifyHttp(server).times(2, 
+		verifyHttp(server).times(1, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}

--- a/cli-scanner/src/test/java/com/sap/psr/vulas/cli/VulasCliTest.java
+++ b/cli-scanner/src/test/java/com/sap/psr/vulas/cli/VulasCliTest.java
@@ -95,7 +95,7 @@ public class VulasCliTest extends AbstractGoalTest {
 		verifyHttp(server).times(1, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.app(testApp)));
-		verifyHttp(server).times(2, 
+		verifyHttp(server).times(1, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}
@@ -127,7 +127,7 @@ public class VulasCliTest extends AbstractGoalTest {
 		verifyHttp(server).times(1, 
 				method(Method.PUT),
 				uri("/backend" + PathBuilder.app(this.testApp)));
-		verifyHttp(server).times(2, 
+		verifyHttp(server).times(1, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}
@@ -168,7 +168,7 @@ public class VulasCliTest extends AbstractGoalTest {
 		verifyHttp(server).times(1, 
 				method(Method.PUT),
 				uri("/backend" + PathBuilder.app(this.testApp)));
-		verifyHttp(server).times(2, 
+		verifyHttp(server).times(1, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}

--- a/cli-scanner/src/test/java/com/sap/psr/vulas/cli/VulasCliTest.java
+++ b/cli-scanner/src/test/java/com/sap/psr/vulas/cli/VulasCliTest.java
@@ -1,6 +1,5 @@
 package com.sap.psr.vulas.cli;
 
-import static com.jayway.restassured.RestAssured.expect;
 import static com.xebialabs.restito.builder.stub.StubHttp.whenHttp;
 import static com.xebialabs.restito.builder.verify.VerifyHttp.verifyHttp;
 import static com.xebialabs.restito.semantics.Action.charset;
@@ -24,7 +23,6 @@ import org.junit.experimental.categories.Category;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.goals.GoalConfigurationException;
 import com.sap.psr.vulas.goals.GoalExecutionException;
-import com.sap.psr.vulas.shared.categories.Slow;
 import com.sap.psr.vulas.shared.connectivity.PathBuilder;
 import com.sap.psr.vulas.shared.json.JacksonUtil;
 import com.sap.psr.vulas.shared.json.model.Application;
@@ -84,13 +82,8 @@ public class VulasCliTest extends AbstractGoalTest {
 //		.post("/backend" + PathBuilder.goalExcecutions(null, null, _a));
 	}
 
-	/**
-	 * 
-	 */
 	@Test
 	public void testCleanGoal() throws GoalConfigurationException, GoalExecutionException {
-		//System.setProperty(CoreConfiguration.BACKEND_CONNECT, CoreConfiguration.ConnectType.OFFLINE.toString());
-
 		// Mock REST services
 		this.configureBackendServiceUrl(server);
 		this.setupMockServices(this.testApp);
@@ -107,13 +100,8 @@ public class VulasCliTest extends AbstractGoalTest {
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}
 
-	/**
-	 * 
-	 */
 	@Test
 	public void testAppGoal() throws GoalConfigurationException, GoalExecutionException {
-		//System.setProperty(CoreConfiguration.BACKEND_CONNECT, CoreConfiguration.ConnectType.OFFLINE.toString());
-
 		// App: Relative and absolute folders with and without spaces
 		final Path rel_app_with_space = Paths.get("src", "test", "resources", "appfolder with space");
 		final Path abs_app = Paths.get("src", "test", "resources", "appfolder").toAbsolutePath();
@@ -144,13 +132,9 @@ public class VulasCliTest extends AbstractGoalTest {
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}
 
-	/**
-	 * 
-	 */
 	@Test
 	@Category(com.sap.psr.vulas.shared.categories.Slow.class)
 	public void testPyAppGoal() throws GoalConfigurationException, GoalExecutionException {
-		//System.setProperty(CoreConfiguration.BACKEND_CONNECT, CoreConfiguration.ConnectType.OFFLINE.toString());
 		System.setProperty(CoreConfiguration.APP_DIRS, "./src/test/resources/cf-helloworld");
 		
 		// Mock REST services
@@ -169,12 +153,8 @@ public class VulasCliTest extends AbstractGoalTest {
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}
 	
-	/**
-	 * 
-	 */
 	@Test
 	public void testJavaAppGoal() throws GoalConfigurationException, GoalExecutionException {
-		//System.setProperty(CoreConfiguration.BACKEND_CONNECT, CoreConfiguration.ConnectType.OFFLINE.toString());
 		System.setProperty(CoreConfiguration.APP_DIRS, "./src/test/resources/java-app");
 		
 		// Mock REST services

--- a/lang-java-reach-soot/src/main/java/com/sap/psr/vulas/cg/soot/SootCallgraphConstructor.java
+++ b/lang-java-reach-soot/src/main/java/com/sap/psr/vulas/cg/soot/SootCallgraphConstructor.java
@@ -30,8 +30,7 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
 
     private static final Log log = LogFactory.getLog(SootCallgraphConstructor.class);
 
-    private static final String FRAMEWORK = "soot";
-
+    public static final String FRAMEWORK = "soot";
 
     private long buildTimeNano = -1;
 
@@ -41,7 +40,8 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
      * The context information of the application JAR to be analyzed
      */
     private Application appContext = null;
-
+    
+    private VulasConfiguration vulasConfiguration = null;
 
     /**
      * The JAR to be analyzed.
@@ -61,18 +61,17 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
      */
     public void setAppContext(Application _ctx) {
         this.appContext = _ctx;
-
+    }
+    
+    public void setVulasConfiguration(VulasConfiguration _cfg) {
+    	this.vulasConfiguration = _cfg;
     }
 
     public Application getAppContext() {
         return this.appContext;
     }
 
-
-    public String getFramework() {
-        return SootCallgraphConstructor.FRAMEWORK;
-    }
-
+    public String getFramework() { return SootCallgraphConstructor.FRAMEWORK; }
 
     public void setDepClasspath(String _dependenciesClasspath) {
         if (this.classpath != null) {
@@ -106,8 +105,8 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
     /**
      * Returns a human-readable description of the constructor's specific configuration.
      */
-    public Configuration getConfiguration() {
-        return VulasConfiguration.getGlobal().getConfiguration().subset(SootConfiguration.SOOT_CONFIGURATION_SETTINGS);
+    public Configuration getConstructorConfiguration() {
+        return this.vulasConfiguration.getConfiguration().subset(SootConfiguration.SOOT_CONFIGURATION_SETTINGS);
     }
 
 
@@ -121,13 +120,13 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
         G.v().resetSpark();
         G.reset();
 
-        boolean verbose = VulasConfiguration.getGlobal().getConfiguration().getBoolean(SootConfiguration.SOOT_VERBOSE);
+        boolean verbose = this.vulasConfiguration.getConfiguration().getBoolean(SootConfiguration.SOOT_VERBOSE);
 
 
         // set default excluded list to empty list
         // Options.v().set_include_all(true);
 
-        String excludedPackages = VulasConfiguration.getGlobal().getConfiguration().getString(SootConfiguration.SOOT_EXCLUSIONS);
+        String excludedPackages = this.vulasConfiguration.getConfiguration().getString(SootConfiguration.SOOT_EXCLUSIONS);
         List<String> excludedList = Arrays.asList(excludedPackages.split(";"));
         Options.v().set_exclude(excludedList);
 
@@ -136,9 +135,9 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
         Options.v().set_prepend_classpath(true);
 
         // Read from soot-cfg.properties
-        Options.v().set_allow_phantom_refs(VulasConfiguration.getGlobal().getConfiguration().getBoolean(SootConfiguration.SOOT_ALLOW_PHANTOM));
+        Options.v().set_allow_phantom_refs(this.vulasConfiguration.getConfiguration().getBoolean(SootConfiguration.SOOT_ALLOW_PHANTOM));
         Options.v().set_verbose(verbose);
-        Options.v().set_app(VulasConfiguration.getGlobal().getConfiguration().getBoolean(SootConfiguration.SOOT_APP_MODE));
+        Options.v().set_app(this.vulasConfiguration.getConfiguration().getBoolean(SootConfiguration.SOOT_APP_MODE));
         Options.v().set_whole_program(true);
         Options.v().setPhaseOption("cg", "safe-forname:" + false);
 
@@ -154,17 +153,17 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
         Options.v().set_output_format(Options.output_format_none);
 
         // with this option we get only method signatures but not their bodies
-        Options.v().set_no_bodies_for_excluded(VulasConfiguration.getGlobal().getConfiguration().getBoolean(SootConfiguration.SOOT_NOBODY_FOR_X));
+        Options.v().set_no_bodies_for_excluded(this.vulasConfiguration.getConfiguration().getBoolean(SootConfiguration.SOOT_NOBODY_FOR_X));
 
-        if (VulasConfiguration.getGlobal().getConfiguration().getBoolean(SootConfiguration.SOOT_SPARK)) {
+        if (this.vulasConfiguration.getConfiguration().getBoolean(SootConfiguration.SOOT_SPARK)) {
             String s = "on";
-            if (VulasConfiguration.getGlobal().getConfiguration().getBoolean(SootConfiguration.SOOT_SPARK_OTF))
+            if (this.vulasConfiguration.getConfiguration().getBoolean(SootConfiguration.SOOT_SPARK_OTF))
                 s += ",on-fly-cg:true";
             else s += ",on-fly-cg:false";
-            if (VulasConfiguration.getGlobal().getConfiguration().getBoolean(SootConfiguration.SOOT_SPARK_VTA))
+            if (this.vulasConfiguration.getConfiguration().getBoolean(SootConfiguration.SOOT_SPARK_VTA))
                 s += ",vta:true";
             else s += ",vta:false";
-            if (VulasConfiguration.getGlobal().getConfiguration().getBoolean(SootConfiguration.SOOT_SPARK_RTA))
+            if (this.vulasConfiguration.getConfiguration().getBoolean(SootConfiguration.SOOT_SPARK_RTA))
                 s += ",rta:true";
             else s += ",rta:false";
             SootCallgraphConstructor.log.info("Enabled cg.spark with settings [" + s + "]");
@@ -300,7 +299,7 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
 
 
     private ArrayList<SootMethod> createEntryPoint4Soot(Collection<SootMethod> selectedEntrypoints) {
-        String slcEntrypointGenerator = VulasConfiguration.getGlobal().getConfiguration().getString(SootConfiguration.SOOT_ENTRYPOINT_GENERATOR);
+        String slcEntrypointGenerator = this.vulasConfiguration.getConfiguration().getString(SootConfiguration.SOOT_ENTRYPOINT_GENERATOR);
 
 
         if (slcEntrypointGenerator.toLowerCase().equals("none")) {
@@ -469,8 +468,8 @@ public class SootCallgraphConstructor implements ICallgraphConstructor {
     public void setExcludePackages(String _packages) {
         // Overwrite configuration (if requested)
         if (_packages != null && !_packages.equals(""))
-            VulasConfiguration.getGlobal().setProperty(SootConfiguration.SOOT_EXCLUSIONS, _packages);
-        SootCallgraphConstructor.log.info("Set packages to be excluded [ " + VulasConfiguration.getGlobal().getConfiguration().getString(SootConfiguration.SOOT_EXCLUSIONS) + " ]");
+            this.vulasConfiguration.setProperty(SootConfiguration.SOOT_EXCLUSIONS, _packages);
+        SootCallgraphConstructor.log.info("Set packages to be excluded [ " + this.vulasConfiguration.getConfiguration().getString(SootConfiguration.SOOT_EXCLUSIONS) + " ]");
     }
 }
 

--- a/lang-java-reach-soot/src/test/java/SootCallGraphTest.java
+++ b/lang-java-reach-soot/src/test/java/SootCallGraphTest.java
@@ -1,3 +1,15 @@
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
 import com.sap.psr.vulas.cg.ReachabilityAnalyzer;
 import com.sap.psr.vulas.cg.soot.SootCallgraphConstructor;
 import com.sap.psr.vulas.cg.spi.CallgraphConstructorFactory;
@@ -9,21 +21,9 @@ import com.sap.psr.vulas.shared.enums.PathSource;
 import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.json.model.ConstructId;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
-import org.junit.Test;
-import soot.SootClass;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class SootCallGraphTest {
-
+	
 	static{
 		VulasConfiguration.getGlobal().setProperty(CoreConfiguration.BACKEND_CONNECT, CoreConfiguration.ConnectType.OFFLINE.toString());
 	}
@@ -31,13 +31,13 @@ public class SootCallGraphTest {
     private GoalContext getGoalContext() {
         final GoalContext ctx = new GoalContext();
         ctx.setApplication(new Application("foo", "bar", "0.0"));
+        ctx.setVulasConfiguration(VulasConfiguration.getGlobal());
         return ctx;
     }
 
-
     private void runSootAnalysis() {
         final ReachabilityAnalyzer ra = new ReachabilityAnalyzer(this.getGoalContext());
-        ra.setCallgraphConstructor("soot", false);
+        ra.setCallgraphConstructor(SootCallgraphConstructor.FRAMEWORK, false);
         // Set classpaths
         final Set<Path> app_paths = new HashSet<Path>(), dep_paths = new HashSet<Path>();
         app_paths.add(Paths.get("./src/test/resources/examples.jar"));
@@ -82,8 +82,6 @@ public class SootCallGraphTest {
     public void examplesSootTestNoneEntrypointGenerator() {
         VulasConfiguration.getGlobal().setProperty("vulas.reach.soot.entrypointGenerator", "none");
         runSootAnalysis();
-
-
     }
 
     @Test
@@ -97,6 +95,4 @@ public class SootCallGraphTest {
         VulasConfiguration.getGlobal().setProperty("vulas.reach.soot.entrypointGenerator", "com.sap.psr.vulas.cg.soot.CustomEntryPointCreator");
         runSootAnalysis();
     }
-
-
 }

--- a/lang-java-reach-wala/src/main/java/com/sap/psr/vulas/cg/wala/WalaCallgraphConstructor.java
+++ b/lang-java-reach-wala/src/main/java/com/sap/psr/vulas/cg/wala/WalaCallgraphConstructor.java
@@ -46,11 +46,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
 public class WalaCallgraphConstructor implements ICallgraphConstructor {
 
     private static final Log log = LogFactory.getLog(WalaCallgraphConstructor.class);
-    private static final String FRAMEWORK = "wala";
-
-    public String getFramework() {
-        return WalaCallgraphConstructor.FRAMEWORK;
-    }
+    public static final String FRAMEWORK = "wala";
 
     // Packages to be excluded for call graph construction, which is read from wala-cfg.properties
     private File excludedPackagesFile = null;
@@ -59,9 +55,17 @@ public class WalaCallgraphConstructor implements ICallgraphConstructor {
      * The context information of the application JAR to be analyzed
      */
     private Application appContext = null;
+    
+    private VulasConfiguration vulasConfiguration = null;
 
+    public String getFramework() { return WalaCallgraphConstructor.FRAMEWORK; }
+    
     public Application getAppContext() {
         return this.appContext;
+    }
+    
+    public void setVulasConfiguration(VulasConfiguration _cfg) {
+    	this.vulasConfiguration = _cfg;
     }
 
     /**
@@ -272,8 +276,8 @@ public class WalaCallgraphConstructor implements ICallgraphConstructor {
     /**
      * Returns a human-readable description of the constructor's specific configuration.
      */
-    public Configuration getConfiguration() {
-        return VulasConfiguration.getGlobal().getConfiguration().subset("vulas.reach.wala");
+    public Configuration getConstructorConfiguration() {
+        return this.vulasConfiguration.getConfiguration().subset("vulas.reach.wala");
     }
 
     /**
@@ -287,13 +291,13 @@ public class WalaCallgraphConstructor implements ICallgraphConstructor {
         try {
             //String[] args = new String[]{"-appJar", this.classpath, "-cg", VulasConfiguration.getSingleton().getConfiguration().getString("vulas.reach.wala.callgraph.algorithm")};
             //CommandLine.parse(args);
-            String cg_algorithm = VulasConfiguration.getGlobal().getConfiguration().getString("vulas.reach.wala.callgraph.algorithm");
-            WalaCallgraphConstructor.log.info("Using algorithm [" + cg_algorithm + "], reflection option [" + VulasConfiguration.getGlobal().getConfiguration().getString("vulas.reach.wala.callgraph.reflection") + "]");
+            String cg_algorithm = this.vulasConfiguration.getConfiguration().getString("vulas.reach.wala.callgraph.algorithm");
+            WalaCallgraphConstructor.log.info("Using algorithm [" + cg_algorithm + "], reflection option [" + this.vulasConfiguration.getConfiguration().getString("vulas.reach.wala.callgraph.reflection") + "]");
             final long start_nanos = System.nanoTime();
 
             // encapsulates various analysis options
             AnalysisOptions options = new AnalysisOptions(this.scope, this.entrypoints);
-            options.setReflectionOptions(ReflectionOptions.valueOf(VulasConfiguration.getGlobal().getConfiguration().getString("vulas.reach.wala.callgraph.reflection")));
+            options.setReflectionOptions(ReflectionOptions.valueOf(this.vulasConfiguration.getConfiguration().getString("vulas.reach.wala.callgraph.reflection")));
             // callgraph builder based on algorithm
             CallGraphBuilder<?> builder = null;
 
@@ -413,10 +417,10 @@ public class WalaCallgraphConstructor implements ICallgraphConstructor {
 
         // Overwrite configuration (if requested)
         if (_packages != null && !_packages.equals(""))
-            VulasConfiguration.getGlobal().setProperty("vulas.reach.wala.callgraph.exclusions", _packages);
+            this.vulasConfiguration.setProperty("vulas.reach.wala.callgraph.exclusions", _packages);
 
         // Get configuration (original or overwritten)
-        final String buffer = VulasConfiguration.getGlobal().getConfiguration().getString("vulas.reach.wala.callgraph.exclusions");
+        final String buffer = this.vulasConfiguration.getConfiguration().getString("vulas.reach.wala.callgraph.exclusions");
 
         // Write exluded packages into file
         try {

--- a/lang-java-reach-wala/src/test/java/WalaCallGraphTest.java
+++ b/lang-java-reach-wala/src/test/java/WalaCallGraphTest.java
@@ -31,6 +31,7 @@ public class WalaCallGraphTest {
     private GoalContext getGoalContext() {
         final GoalContext ctx = new GoalContext();
         ctx.setApplication(new Application("foo", "bar", "0.0"));
+        ctx.setVulasConfiguration(new VulasConfiguration());
         return ctx;
     }
 
@@ -46,7 +47,7 @@ public class WalaCallGraphTest {
     @Test
     public void examplesWalaTest() {
         final ReachabilityAnalyzer ra = new ReachabilityAnalyzer(this.getGoalContext());
-        ra.setCallgraphConstructor("wala", false);
+        ra.setCallgraphConstructor(WalaCallgraphConstructor.FRAMEWORK, false);
 
         // Set classpaths
         final Set<Path> app_paths = new HashSet<Path>(), dep_paths = new HashSet<Path>();

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/A2CGoal.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/A2CGoal.java
@@ -21,7 +21,7 @@ public class A2CGoal extends AbstractReachGoal {
 	protected final Set<com.sap.psr.vulas.shared.json.model.ConstructId> getEntryPoints() {
 		if(this.entryPoints==null) {
 			// Filter app constructs (if requested)
-			final String[] filter = VulasConfiguration.getGlobal().getConfiguration().getStringArray(ReachabilityConfiguration.REACH_CONSTR_FILTER);
+			final String[] filter = this.getConfiguration().getConfiguration().getStringArray(ReachabilityConfiguration.REACH_CONSTR_FILTER);
 			if(filter!=null && filter.length>0 && !(filter.length==1 && filter[0].equals(""))) {
 				this.entryPoints = ConstructIdUtil.filterWithRegex(this.getAppConstructs(), filter);
 			} else {
@@ -35,6 +35,6 @@ public class A2CGoal extends AbstractReachGoal {
 	 * Sets the application constructs as entry points of the {@link ReachabilityAnalyzer}.
 	 */
 	protected final void setEntryPoints(ReachabilityAnalyzer _ra) {
-		_ra.setEntryPoints(this.getEntryPoints(), PathSource.A2C, VulasConfiguration.getGlobal().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_EXIT_UNKOWN_EP, false));
+		_ra.setEntryPoints(this.getEntryPoints(), PathSource.A2C, this.getConfiguration().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_EXIT_UNKOWN_EP, false));
 	}
 }

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/AbstractReachGoal.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/AbstractReachGoal.java
@@ -66,9 +66,9 @@ public abstract class AbstractReachGoal extends AbstractAppGoal {
         final FileSearch jar_search = new FileSearch(JAR_EXT);
         final FileSearch class_search = new FileSearch(CLASS_EXT);
 
-        final boolean preprocess = VulasConfiguration.getGlobal().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_PREPROCESS, true);
+        final boolean preprocess = this.getConfiguration().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_PREPROCESS, true);
 
-        final StringList exclude_jars = new StringList(VulasConfiguration.getGlobal().getConfiguration().getStringArray(ReachabilityConfiguration.REACH_EXCL_JARS));
+        final StringList exclude_jars = new StringList(this.getConfiguration().getConfiguration().getStringArray(ReachabilityConfiguration.REACH_EXCL_JARS));
 
         // Append known dependencies to classpath (can be none in case of CLI)
         for (Path p : this.getKnownDependencies().keySet()) {
@@ -160,13 +160,13 @@ public abstract class AbstractReachGoal extends AbstractAppGoal {
         this.setEntryPoints(ra);
 
         //set the call graph constructor, based on the configured framework
-        ra.setCallgraphConstructor(VulasConfiguration.getGlobal().getConfiguration().getString(ReachabilityConfiguration.REACH_FWK, "wala"), this.getGoalClient() == GoalClient.CLI);
+        ra.setCallgraphConstructor(this.getConfiguration().getConfiguration().getString(ReachabilityConfiguration.REACH_FWK, "wala"), this.getGoalClient() == GoalClient.CLI);
 
-        ra.setTargetConstructs(VulasConfiguration.getGlobal().getConfiguration().getString(ReachabilityConfiguration.REACH_BUGS, null));
-        ra.setExcludePackages(VulasConfiguration.getGlobal().getConfiguration().getString(ReachabilityConfiguration.REACH_EXCL_PACK, null));
+        ra.setTargetConstructs(this.getConfiguration().getConfiguration().getString(ReachabilityConfiguration.REACH_BUGS, null));
+        ra.setExcludePackages(this.getConfiguration().getConfiguration().getString(ReachabilityConfiguration.REACH_EXCL_PACK, null));
 
         // Trigger the analysis
-        final boolean success = ReachabilityAnalyzer.startAnalysis(ra, VulasConfiguration.getGlobal().getConfiguration().getInt(ReachabilityConfiguration.REACH_TIMEOUT, 15) * 60L * 1000L);
+        final boolean success = ReachabilityAnalyzer.startAnalysis(ra, this.getConfiguration().getConfiguration().getInt(ReachabilityConfiguration.REACH_TIMEOUT, 15) * 60L * 1000L);
 
         // Upload
         if (success)
@@ -186,7 +186,7 @@ public abstract class AbstractReachGoal extends AbstractAppGoal {
      */
     @Override
     protected final void cleanAfterExecution() {
-        if (VulasConfiguration.getGlobal().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_PREPROCESS, true)) {
+        if (this.getConfiguration().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_PREPROCESS, true)) {
         	log.info("Deleting [" + this.rewrittenJars.size() + "] temporary (pre-processed) dependencies...");
             for (Path p : this.rewrittenJars) {
                 try {

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/ReachabilityAnalyzer.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/ReachabilityAnalyzer.java
@@ -247,8 +247,9 @@ public class ReachabilityAnalyzer implements Runnable {
         this.targetConstructs = _target_constructs;
     }
 
-    public void setCallgraphConstructor(String analysisFramework, boolean cliGoal) {
-        this.constructor = CallgraphConstructorFactory.buildCallgraphConstructor(analysisFramework, this.app_ctx, cliGoal);
+    public void setCallgraphConstructor(String analysisFramework, boolean _is_cli) {
+        this.constructor = CallgraphConstructorFactory.buildCallgraphConstructor(analysisFramework, this.app_ctx, _is_cli);
+        this.constructor.setVulasConfiguration(this.goalContext.getVulasConfiguration());
     }
 
     private Graph<ConstructId> readFromDisk(String _file) {
@@ -364,7 +365,7 @@ public class ReachabilityAnalyzer implements Runnable {
                 // Sources for the reachability analysis (= always the same, independent of the current bug)
                 final Set<com.sap.psr.vulas.shared.json.model.ConstructId> src_ep = constructor.getEntrypoints();
 
-                final boolean search_shortest = VulasConfiguration.getGlobal().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_SEARCH_SHORTEST, true);
+                final boolean search_shortest = this.goalContext.getVulasConfiguration().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_SEARCH_SHORTEST, true);
 
                 final StopWatch sw = new StopWatch("Check reachability of change list elements").start();
 
@@ -461,7 +462,7 @@ public class ReachabilityAnalyzer implements Runnable {
      */
     private void identifyTouchPoints() {
         // Allow to skip the collection of touch points (which is potentially time consuming due to nested looping over app methods and all their edges)
-        final boolean identify_touchpoints = VulasConfiguration.getGlobal().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_TOUCHPOINTS, true);
+        final boolean identify_touchpoints = this.goalContext.getVulasConfiguration().getConfiguration().getBoolean(ReachabilityConfiguration.REACH_TOUCHPOINTS, true);
         if (!identify_touchpoints)
             log.warn("Identification of touch points disabled per configuration");
 
@@ -537,7 +538,7 @@ public class ReachabilityAnalyzer implements Runnable {
      * Returns a human-readable description of the constructor's specific configuration.
      */
     public Configuration getConfiguration() {
-        return (constructor == null ? null : constructor.getConfiguration());
+        return (constructor == null ? null : constructor.getConstructorConfiguration());
     }
 
     /**
@@ -658,7 +659,7 @@ public class ReachabilityAnalyzer implements Runnable {
     public synchronized void uploadBug(String _bugid, List<List<ConstructId>> _paths) {
 
         // Used to limit the number of paths (per change list element) that will be uploaded to the backend
-        final int max_path = VulasConfiguration.getGlobal().getConfiguration().getInt(ReachabilityConfiguration.REACH_MAX_PATH, 10);
+        final int max_path = this.goalContext.getVulasConfiguration().getConfiguration().getInt(ReachabilityConfiguration.REACH_MAX_PATH, 10);
         final Map<com.sap.psr.vulas.shared.json.model.ConstructId, Integer> counters = new HashMap<com.sap.psr.vulas.shared.json.model.ConstructId, Integer>();
         int count = -1;
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/spi/CallgraphConstructorFactory.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/spi/CallgraphConstructorFactory.java
@@ -1,22 +1,22 @@
 package com.sap.psr.vulas.cg.spi;
 
-import com.sap.psr.vulas.cg.ReachabilityConfiguration;
-import com.sap.psr.vulas.shared.json.model.Application;
-import com.sap.psr.vulas.shared.util.VulasConfiguration;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.sap.psr.vulas.cg.ReachabilityConfiguration;
+import com.sap.psr.vulas.shared.json.model.Application;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 public class CallgraphConstructorFactory {
 

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/spi/ICallgraphConstructor.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/spi/ICallgraphConstructor.java
@@ -2,12 +2,13 @@ package com.sap.psr.vulas.cg.spi;
 
 import java.util.Set;
 
-import com.sap.psr.vulas.cg.CallgraphConstructException;
-import com.sap.psr.vulas.shared.json.model.Application;
 import org.apache.commons.configuration.Configuration;
 
 import com.ibm.wala.util.graph.Graph;
 import com.sap.psr.vulas.Construct;
+import com.sap.psr.vulas.cg.CallgraphConstructException;
+import com.sap.psr.vulas.shared.json.model.Application;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 /**
  * A call graph constructor builds a call graph starting from a given set of entry points. Entry points can be, for instance,
@@ -28,6 +29,8 @@ public interface ICallgraphConstructor {
      */
     public void setAppContext(Application _ctx);
 
+    public void setVulasConfiguration(VulasConfiguration _cfg);
+    
     /**
      * Sets the class path with directories and/or JAR files for the application. Individual entries must be separated by the system-specific path separator.
      *
@@ -81,9 +84,9 @@ public interface ICallgraphConstructor {
     public long getConstructionTime();
 
     /**
-     * Returns the constructor's specific configuration.
+     * Returns the constructor's specific configuration settings.
      */
-    public Configuration getConfiguration();
+    public Configuration getConstructorConfiguration();
 
     /**
      * Returns the call graph.

--- a/lang-java/pom.xml
+++ b/lang-java/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>com.google.inject.extensions</groupId>
 			<artifactId>guice-assistedinject</artifactId>
-			<version>4.1.0</version><!-- 3.0 in the original POM from ChangeDistiller -->
+			<version>4.2.2</version><!-- 3.0 in the original POM from ChangeDistiller -->
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jdt.core.compiler</groupId>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.8</version>
+			<version>3.8.1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/goals/InstrGoal.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/goals/InstrGoal.java
@@ -90,21 +90,21 @@ public class InstrGoal extends AbstractAppGoal {
 
 		try {
 			// Lib path
-			this.setLibPath(FileUtil.getPath(VulasConfiguration.getGlobal().getConfiguration().getString(CoreConfiguration.INSTR_LIB_DIR, null)));
+			this.setLibPath(FileUtil.getPath(this.getConfiguration().getConfiguration().getString(CoreConfiguration.INSTR_LIB_DIR, null)));
 
 			// Warn if there's no lib path
 			if(!this.hasLibPath())
 				log.warn("No library path");
 
 			// Include path
-			this.setInclPath(FileUtil.getPath(VulasConfiguration.getGlobal().getConfiguration().getString(CoreConfiguration.INSTR_INCLUDE_DIR, null)));
+			this.setInclPath(FileUtil.getPath(this.getConfiguration().getConfiguration().getString(CoreConfiguration.INSTR_INCLUDE_DIR, null)));
 
 			// Warn if there's no include path
 			if(!this.hasInclPath())
 				log.warn("No path with to-be-included JAR files");
 
 			// Where the instrumented archives will be written to
-			this.setTargetPath(FileUtil.getPath(VulasConfiguration.getGlobal().getConfiguration().getString(CoreConfiguration.INSTR_TARGET_DIR, null), true));
+			this.setTargetPath(FileUtil.getPath(this.getConfiguration().getConfiguration().getString(CoreConfiguration.INSTR_TARGET_DIR, null), true));
 
 			// Warn if there's no target path
 			if(!this.hasTargetPath()) {
@@ -113,7 +113,7 @@ public class InstrGoal extends AbstractAppGoal {
 			}
 			
 			// Instrumentation paths?
-			this.addInstrPaths(FileUtil.getPaths(VulasConfiguration.getGlobal().getStringArray(CoreConfiguration.INSTR_SRC_DIR, null)));
+			this.addInstrPaths(FileUtil.getPaths(this.getConfiguration().getStringArray(CoreConfiguration.INSTR_SRC_DIR, null)));
 
 			// Warn if there's no app path
 			if(!this.hasInstrPaths()) {
@@ -138,7 +138,7 @@ public class InstrGoal extends AbstractAppGoal {
 
 		//TODO: Check how to use packaging information from the Maven plugin
 
-		final int no_threads = ThreadUtil.getNoThreads(2);
+		final int no_threads = ThreadUtil.getNoThreads(this.getConfiguration(), 2);
 		final JarAnalysisManager mgr = new JarAnalysisManager(no_threads, true, app);
 		mgr.setRename(true);
 
@@ -154,7 +154,7 @@ public class InstrGoal extends AbstractAppGoal {
 
 		// Search source archives and go
 		final FileSearch vis = new FileSearch(AbstractGoal.JAR_WAR_EXT);
-		final int search_depth = VulasConfiguration.getGlobal().getConfiguration().getBoolean(CoreConfiguration.INSTR_SEARCH_RECURSIVE, false) ? Integer.MAX_VALUE : 1;
+		final int search_depth = this.getConfiguration().getConfiguration().getBoolean(CoreConfiguration.INSTR_SEARCH_RECURSIVE, false) ? Integer.MAX_VALUE : 1;
 		mgr.startAnalysis(vis.search(getInstrPaths(), search_depth), null);
 
 		// Add goal stats

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/tasks/JavaBomTask.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/tasks/JavaBomTask.java
@@ -63,10 +63,11 @@ public class JavaBomTask extends AbstractBomTask {
 	}
 
 	@Override
-	public void configure() throws GoalConfigurationException {
+	public void configure(VulasConfiguration _cfg) throws GoalConfigurationException {
+		super.configure(_cfg);
 
 		// App constructs identified using package prefixes
-		this.appPrefixes = VulasConfiguration.getGlobal().getStringArray(CoreConfiguration.APP_PREFIXES, null);
+		this.appPrefixes = _cfg.getStringArray(CoreConfiguration.APP_PREFIXES, null);
 
 		// Print warning message in case the setting is used as part of the Maven plugin
 		if(this.appPrefixes!=null && this.isOneOfGoalClients(pluginGoalClients)) {
@@ -75,7 +76,7 @@ public class JavaBomTask extends AbstractBomTask {
 		}
 
 		// App constructs identified using JAR file name patterns (regex)
-		final String[] app_jar_names = VulasConfiguration.getGlobal().getStringArray(CoreConfiguration.APP_JAR_NAMES, null);
+		final String[] app_jar_names = _cfg.getStringArray(CoreConfiguration.APP_JAR_NAMES, null);
 		if(app_jar_names!=null) {
 			// Print warning message in case the setting is used as part of the Maven plugin
 			if( this.isOneOfGoalClients(pluginGoalClients)) {

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/AbstractInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/AbstractInstrumentor.java
@@ -1,14 +1,16 @@
 package com.sap.psr.vulas.monitor;
 
 import com.sap.psr.vulas.java.JavaId;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 import javassist.CtBehavior;
 import javassist.CtClass;
 import javassist.CtMethod;
 import javassist.Modifier;
-import javassist.NotFoundException;
 
 public abstract class AbstractInstrumentor implements IInstrumentor {
+	
+	protected VulasConfiguration vulasConfiguration = new VulasConfiguration();
 
 	/**
 	 * Adds Java code to determine the URL of the resource from which the given class was loaded, and the class loader which loaded it.

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/ExecutionMonitor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/ExecutionMonitor.java
@@ -134,7 +134,7 @@ public class ExecutionMonitor {
 				exe.addGoalStats("test." + i.getClass().getSimpleName(), i.getStatistics());
 			}
 
-			this.exe.upload();
+			this.exe.upload(false);
 		}
 	}
 

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/SingleStackTraceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/SingleStackTraceInstrumentor.java
@@ -11,6 +11,7 @@ import com.sap.psr.vulas.ConstructId;
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
+import com.sap.psr.vulas.goals.GoalContext;
 import com.sap.psr.vulas.java.JavaId;
 import com.sap.psr.vulas.monitor.ClassVisitor;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
@@ -40,9 +41,10 @@ public class SingleStackTraceInstrumentor extends AbstractTraceInstrumentor {
 	private int maxStacktraces = -1;
 
 	public SingleStackTraceInstrumentor() {
-		this.maxStacktraces = VulasConfiguration.getGlobal().getConfiguration().getInt(CoreConfiguration.INSTR_MAX_STACKTRACES, 10);
+		final GoalContext gc = CoreConfiguration.buildGoalContextFromConfiguration(this.vulasConfiguration);
+		this.maxStacktraces = this.vulasConfiguration.getConfiguration().getInt(CoreConfiguration.INSTR_MAX_STACKTRACES, 10);
 		try {
-			final Map<String, Set<com.sap.psr.vulas.shared.json.model.ConstructId>> bug_change_lists = BackendConnector.getInstance().getAppBugs(CoreConfiguration.buildGoalContextFromGlobalConfiguration(), CoreConfiguration.getAppContext());
+			final Map<String, Set<com.sap.psr.vulas.shared.json.model.ConstructId>> bug_change_lists = BackendConnector.getInstance().getAppBugs(gc, CoreConfiguration.getAppContext(this.vulasConfiguration));
 			this.constructsCollectStacktrace = AbstractTraceInstrumentor.merge(bug_change_lists);
 		} catch (ConfigurationException e) {
 			SingleStackTraceInstrumentor.log.error("Error during instantiation: " + e.getMessage());

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/trace/StackTraceInstrumentor.java
@@ -38,7 +38,7 @@ public class StackTraceInstrumentor extends AbstractTraceInstrumentor {
 
 	public StackTraceInstrumentor() {
 		try {
-			final Map<String, Set<com.sap.psr.vulas.shared.json.model.ConstructId>> bug_change_lists = BackendConnector.getInstance().getAppBugs(CoreConfiguration.buildGoalContextFromGlobalConfiguration(), CoreConfiguration.getAppContext());
+			final Map<String, Set<com.sap.psr.vulas.shared.json.model.ConstructId>> bug_change_lists = BackendConnector.getInstance().getAppBugs(CoreConfiguration.buildGoalContextFromConfiguration(this.vulasConfiguration), CoreConfiguration.getAppContext(this.vulasConfiguration));
 			this.constructsCollectStacktrace = AbstractTraceInstrumentor.merge(bug_change_lists);
 		} catch (ConfigurationException e) {
 			StackTraceInstrumentor.log.error("Error during instantiation: " + e.getMessage());

--- a/lang-python/src/main/java/com/sap/psr/vulas/python/tasks/PythonBomTask.java
+++ b/lang-python/src/main/java/com/sap/psr/vulas/python/tasks/PythonBomTask.java
@@ -44,7 +44,9 @@ public class PythonBomTask extends AbstractBomTask {
 	public Set<ProgrammingLanguage> getLanguage() { return new HashSet<ProgrammingLanguage>(Arrays.asList(new ProgrammingLanguage[] { ProgrammingLanguage.PY })); }
 
 	@Override
-	public void configure() throws GoalConfigurationException {}
+	public void configure(VulasConfiguration _cfg) throws GoalConfigurationException {
+		super.configure(_cfg);
+	}
 
 	@Override
 	public void execute() throws GoalExecutionException {
@@ -57,7 +59,7 @@ public class PythonBomTask extends AbstractBomTask {
 		//final Set<Dependency> app_deps = new HashSet<Dependency>();
 
 		// No pip installation path provided: Search for setup.py
-		if(VulasConfiguration.getGlobal().isEmpty(PythonConfiguration.PY_PIP_PATH)) {
+		if(this.vulasConfiguration.isEmpty(PythonConfiguration.PY_PIP_PATH)) {
 			log.info("Determine app dependencies by finding setup.py files below the search path(s), and installing them in virtual environments");
 
 			// Find all dirs with setup.py
@@ -87,7 +89,7 @@ public class PythonBomTask extends AbstractBomTask {
 		// Pip installation path provided: Call pip to get installed packages
 		else {
 			try {
-				final String pip_path = VulasConfiguration.getGlobal().getConfiguration().getString(PythonConfiguration.PY_PIP_PATH);
+				final String pip_path = this.vulasConfiguration.getConfiguration().getString(PythonConfiguration.PY_PIP_PATH);
 				log.info("Determine app dependencies using [" + pip_path + "]");
 				final PipWrapper pip = new PipWrapper(Paths.get(pip_path), (Path)null);
 				app_pip_packs.addAll(pip.getFreezePackages());

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
@@ -14,6 +14,7 @@ import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.HttpMethod;
 import com.sap.psr.vulas.backend.HttpResponse;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
+import com.sap.psr.vulas.goals.GoalContext;
 
 public class ConditionalHttpRequest extends BasicHttpRequest {
 
@@ -36,6 +37,14 @@ public class ConditionalHttpRequest extends BasicHttpRequest {
 	 */
 	public ConditionalHttpRequest addCondition(ResponseCondition _condition) {
 		this.conditions.add(_condition);
+		return this;
+	}
+	
+	@Override
+	public HttpRequest setGoalContext(GoalContext _ctx) {
+		this.context = _ctx;
+		if(this.conditionRequest!=null)
+			this.conditionRequest.setGoalContext(_ctx);
 		return this;
 	}
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
@@ -48,7 +48,7 @@ public class ConditionalHttpRequest extends BasicHttpRequest {
 			throw new IllegalStateException("No condition request or no conditions set");
 
 		// Conditional requests will be skipped in offline mode
-		if(CoreConfiguration.isBackendOffline()) {
+		if(CoreConfiguration.isBackendOffline(this.context.getVulasConfiguration())) {
 			ConditionalHttpRequest.log.info("Condition(s) not evaluated due to offline mode, do " + this.toString());
 			return super.send();
 		}

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/HttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/HttpRequest.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.HttpResponse;
+import com.sap.psr.vulas.goals.GoalContext;
 
 /**
  * Http request that can be send and saved to (loaded from) disk.
@@ -13,6 +14,10 @@ import com.sap.psr.vulas.backend.HttpResponse;
 public interface HttpRequest extends Serializable {
 
 	public HttpResponse send() throws BackendConnectionException;
+	
+	public GoalContext getGoalContext();
+	
+	public HttpRequest setGoalContext(GoalContext _ctx);
 
 	public void saveToDisk() throws IOException;
 

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/HttpRequestList.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/HttpRequestList.java
@@ -9,6 +9,8 @@ import org.apache.commons.logging.LogFactory;
 
 import com.sap.psr.vulas.backend.BackendConnectionException;
 import com.sap.psr.vulas.backend.HttpResponse;
+import com.sap.psr.vulas.goals.GoalContext;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 public class HttpRequestList extends AbstractHttpRequest {
 	
@@ -19,7 +21,7 @@ public class HttpRequestList extends AbstractHttpRequest {
 	 */
 	private boolean stopOnSuccess = true;
 	
-	private List<BasicHttpRequest> list = new LinkedList<BasicHttpRequest>();
+	private List<HttpRequest> list = new LinkedList<HttpRequest>();
 	
 	public HttpRequestList() { this(true); }
 	
@@ -27,7 +29,15 @@ public class HttpRequestList extends AbstractHttpRequest {
 		this.stopOnSuccess = _stop_on_success;
 	}
 	
-	public void addRequest(BasicHttpRequest _r) { this.list.add(_r); }
+	public void addRequest(HttpRequest _r) { this.list.add(_r); }
+	
+	@Override
+	public HttpRequest setGoalContext(GoalContext _ctx) {
+		this.context = _ctx;
+		for(HttpRequest r: this.list)
+			r.setGoalContext(_ctx);
+		return this;
+	}
 
 	/**
 	 * Loops over the list of requests and calls {@link HttpRequest#send()}. Depending on
@@ -37,7 +47,7 @@ public class HttpRequestList extends AbstractHttpRequest {
 	@Override
 	public HttpResponse send() throws BackendConnectionException {
 		HttpResponse response = null;
-		for(BasicHttpRequest r: this.list) {
+		for(HttpRequest r: this.list) {
 			response = r.send();
 			if(this.stopOnSuccess && response!=null && (response.isOk() || response.isCreated()))
 				break;
@@ -53,21 +63,21 @@ public class HttpRequestList extends AbstractHttpRequest {
 
 	@Override
 	public void savePayloadToDisk() throws IOException {
-		for(BasicHttpRequest r: this.list) {
+		for(HttpRequest r: this.list) {
 			r.savePayloadToDisk();
 		}
 	}
 
 	@Override
 	public void loadPayloadFromDisk() throws IOException {
-		for(BasicHttpRequest r: this.list) {
+		for(HttpRequest r: this.list) {
 			r.loadPayloadFromDisk();
 		}
 	}
 	
 	@Override
 	public void deletePayloadFromDisk() throws IOException {
-		for(BasicHttpRequest r: this.list) {
+		for(HttpRequest r: this.list) {
 			r.deletePayloadFromDisk();
 		}
 	}

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/RequestRepeater.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/RequestRepeater.java
@@ -18,10 +18,6 @@ public class RequestRepeater {
 	private long max = 50;
 	private long waitMilli = 60000;
 
-	public RequestRepeater() {
-		this(VulasConfiguration.getGlobal().getConfiguration().getLong(CoreConfiguration.REPEAT_MAX, 50), VulasConfiguration.getGlobal().getConfiguration().getLong(CoreConfiguration.REPEAT_WAIT, 60000));
-	}
-	
 	public RequestRepeater(long _max, long _milli) {
 		this.max = _max;
 		this.waitMilli = _milli;

--- a/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
+++ b/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
@@ -117,12 +117,12 @@ public class CoreConfiguration {
 
 	private static String vulasRelease = null;
 
-	public static boolean isBackendOffline() { return ConnectType.OFFLINE.equals(getBackendConnectType()); }
-	public static boolean isBackendReadOnly() { return ConnectType.READ_ONLY.equals(getBackendConnectType()); }
-	public static boolean isBackendReadWrite() { return ConnectType.READ_WRITE.equals(getBackendConnectType()); }
+	public static boolean isBackendOffline(VulasConfiguration _c) { return ConnectType.OFFLINE.equals(getBackendConnectType(_c)); }
+	public static boolean isBackendReadOnly(VulasConfiguration _c) { return ConnectType.READ_ONLY.equals(getBackendConnectType(_c)); }
+	public static boolean isBackendReadWrite(VulasConfiguration _c) { return ConnectType.READ_WRITE.equals(getBackendConnectType(_c)); }
 
-	private static ConnectType getBackendConnectType() {
-		final String value = VulasConfiguration.getGlobal().getConfiguration().getString(BACKEND_CONNECT, null);
+	private static ConnectType getBackendConnectType(VulasConfiguration _c) {
+		final String value = _c.getConfiguration().getString(BACKEND_CONNECT, null);
 		if("READ_WRITE".equalsIgnoreCase(value))
 			return ConnectType.READ_WRITE;
 		else if("READ_ONLY".equalsIgnoreCase(value))
@@ -133,13 +133,8 @@ public class CoreConfiguration {
 			throw new IllegalStateException("Illegal value of configuration setting [" + BACKEND_CONNECT + "]: [" + value + "]");
 	} 
 
-	public static boolean isUploadEnabled() {
-		//return VulasConfiguration.getSingleton().getConfiguration().getBoolean(UPLOAD_ENABLED, false);
-		return isBackendReadWrite();
-	}
-
-	public static boolean isJarUploadEnabled() {
-		return VulasConfiguration.getGlobal().getConfiguration().getBoolean(APP_LIB_UPLOAD, false);
+	public static boolean isJarUploadEnabled(VulasConfiguration _vc) {
+		return _vc.getConfiguration().getBoolean(APP_LIB_UPLOAD, false);
 	}
 
 	/**
@@ -148,7 +143,11 @@ public class CoreConfiguration {
 	 * @throws ConfigurationException if the instantiation fails
 	 */
 	public static Application getAppContext() throws ConfigurationException {
-		final Configuration c = VulasConfiguration.getGlobal().getConfiguration();
+		return getAppContext(VulasConfiguration.getGlobal());
+	}
+	
+	public static Application getAppContext(VulasConfiguration _c) throws ConfigurationException {
+		final Configuration c = _c.getConfiguration();
 		Application a = null;
 		try {
 			a = new Application(c.getString(APP_CTX_GROUP), c.getString(APP_CTX_ARTIF), c.getString(APP_CTX_VERSI));
@@ -159,18 +158,29 @@ public class CoreConfiguration {
 			throw new ConfigurationException("Application incomplete: " + a.toString());
 		return a;
 	}
-
+	
 	/**
 	 * Reads the global configuration in order to instantiate a {@link GoalContext}.
 	 * @return a {@link GoalContext) built from the global configuration
 	 */
 	public static final GoalContext buildGoalContextFromGlobalConfiguration() {
-		final Configuration c = VulasConfiguration.getGlobal().getConfiguration();
+		return buildGoalContextFromConfiguration(VulasConfiguration.getGlobal());
+	}
+
+	/**
+	 * Reads the global configuration in order to instantiate a {@link GoalContext}.
+	 * @return a {@link GoalContext) built from the global configuration
+	 */
+	public static final GoalContext buildGoalContextFromConfiguration(VulasConfiguration _c) {
+		final Configuration c = _c.getConfiguration();
+		
 		final GoalContext ctx = new GoalContext();
+		
+		ctx.setVulasConfiguration(_c);
 		
 		// Tenant
 		Tenant tenant = null;
-		if(!VulasConfiguration.getGlobal().isEmpty(CoreConfiguration.TENANT_TOKEN)) {
+		if(!_c.isEmpty(CoreConfiguration.TENANT_TOKEN)) {
 			tenant = new Tenant(c.getString(CoreConfiguration.TENANT_TOKEN)); 
 			ctx.setTenant(tenant);
 //			log.info("Using tenant " + tenant);
@@ -180,7 +190,7 @@ public class CoreConfiguration {
 		}
 		
 		// Space
-		if(!VulasConfiguration.getGlobal().isEmpty(CoreConfiguration.SPACE_TOKEN)) {
+		if(!_c.isEmpty(CoreConfiguration.SPACE_TOKEN)) {
 			final Space space = new Space();
 			space.setSpaceToken(c.getString(CoreConfiguration.SPACE_TOKEN));
 			ctx.setSpace(space);

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractAppGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractAppGoal.java
@@ -10,12 +10,13 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.sap.psr.vulas.backend.BackendConnectionException;
+import com.sap.psr.vulas.backend.BackendConnector;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.enums.GoalType;
 import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.json.model.Dependency;
 import com.sap.psr.vulas.shared.util.FileUtil;
-import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 /**
  * Represents an analysis goal executed in the context of a given {@link Application}.
@@ -87,7 +88,18 @@ public abstract class AbstractAppGoal extends AbstractGoal {
 			//this.handleAppWars();
 			//}
 			
-			// Upload before actual analysis
+			// Verify existance of configured space (if any)
+			if(this.getGoalContext().hasSpace()) {
+				try {
+					final boolean space_exists = BackendConnector.getInstance().isSpaceExisting(this.getGoalContext(), this.getGoalContext().getSpace());
+					if(!space_exists)
+						throw new GoalConfigurationException("Workspace [" + this.getGoalContext().getSpace() + "] cannot be verified: Not present in server");
+				} catch (BackendConnectionException e) {
+					throw new GoalConfigurationException("Workspace [" + this.getGoalContext().getSpace() + "] cannot be verified:" + e.getMessage());
+				}
+			}
+			
+			// Upload goal execution before actual analysis (and another time after goal completion)
 			final boolean created = this.upload();
 			if(!created)
 				throw new GoalConfigurationException("Upload of goal execution failed, aborting the goal execution...");

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractAppGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractAppGoal.java
@@ -100,7 +100,7 @@ public abstract class AbstractAppGoal extends AbstractGoal {
 			}
 			
 			// Upload goal execution before actual analysis (and another time after goal completion)
-			final boolean created = this.upload();
+			final boolean created = this.upload(true);
 			if(!created)
 				throw new GoalConfigurationException("Upload of goal execution failed, aborting the goal execution...");
 		}

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractGoal.java
@@ -114,19 +114,6 @@ public abstract class AbstractGoal implements Runnable {
 		if(_monitor_mem)
 			this.memoThread = new MemoryMonitor();
 
-		final StringList env_whitelist = VulasConfiguration.getGlobal().getStringList(VulasConfiguration.ENV_VARS, VulasConfiguration.ENV_VARS_CUSTOM);
-		final StringList sys_whitelist = VulasConfiguration.getGlobal().getStringList(VulasConfiguration.SYS_PROPS, VulasConfiguration.SYS_PROPS_CUSTOM);
-		
-		// A subset of environment variables
-		this.systemInfo.putAll(env_whitelist.filter(System.getenv(), true, ComparisonMode.EQUALS, CaseSensitivity.CASE_INSENSITIVE));
-
-		// A subset of system properties
-		for(Object key : System.getProperties().keySet()) {
-			final String key_string = (String)key;
-			if(sys_whitelist.contains(key_string, ComparisonMode.STARTSWITH, CaseSensitivity.CASE_INSENSITIVE))
-				this.systemInfo.put(key_string, System.getProperty(key_string));
-		}
-		
 		// Number of processors
 		this.systemInfo.put("runtime.availableProcessors", Integer.toString(Runtime.getRuntime().availableProcessors()));
 	}
@@ -224,8 +211,12 @@ public abstract class AbstractGoal implements Runnable {
 	public synchronized final GoalContext getGoalContext() {
 		if(this.goalContext==null) {
 			final Configuration c = this.getConfiguration().getConfiguration();
+			
 			this.goalContext = new GoalContext();
 
+			// Configuration
+			this.goalContext.setVulasConfiguration(this.getConfiguration());
+			
 			// Tenant
 			if(!this.getConfiguration().isEmpty(CoreConfiguration.TENANT_TOKEN))
 				this.goalContext.setTenant(new Tenant(c.getString(CoreConfiguration.TENANT_TOKEN)));
@@ -446,6 +437,19 @@ public abstract class AbstractGoal implements Runnable {
 		b.append("}");
 
 		// System info
+		final StringList env_whitelist = this.getConfiguration().getStringList(VulasConfiguration.ENV_VARS, VulasConfiguration.ENV_VARS_CUSTOM);
+		final StringList sys_whitelist = this.getConfiguration().getStringList(VulasConfiguration.SYS_PROPS, VulasConfiguration.SYS_PROPS_CUSTOM);
+		
+		// A subset of environment variables
+		this.systemInfo.putAll(env_whitelist.filter(System.getenv(), true, ComparisonMode.EQUALS, CaseSensitivity.CASE_INSENSITIVE));
+
+		// A subset of system properties
+		for(Object key : System.getProperties().keySet()) {
+			final String key_string = (String)key;
+			if(sys_whitelist.contains(key_string, ComparisonMode.STARTSWITH, CaseSensitivity.CASE_INSENSITIVE))
+				this.systemInfo.put(key_string, System.getProperty(key_string));
+		}		
+		
 		b.append(",\"systemInfo\":[");
 		c = 0;
 		for(Map.Entry<String, String> entry: this.systemInfo.entrySet()) {

--- a/lang/src/main/java/com/sap/psr/vulas/goals/AbstractGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/AbstractGoal.java
@@ -185,7 +185,7 @@ public abstract class AbstractGoal implements Runnable {
 		}
 		finally {
 			if(this.goalUploadEnabled)
-				this.upload();
+				this.upload(false);
 		}
 	}
 
@@ -468,11 +468,11 @@ public abstract class AbstractGoal implements Runnable {
 	 * Uploads the JSON presentation of this goal execution to the Vulas backend.
 	 * Returns true of everything went fine (upload succeeded or is not necessary), false otherwise.
 	 */
-	public boolean upload() {
+	public boolean upload(boolean _before) {
 		boolean ret = false;
 		try {
 			AbstractGoal.log.info("Uploading goal execution info ...");
-			ret = BackendConnector.getInstance().uploadGoalExecution(this.getGoalContext(), this);
+			ret = BackendConnector.getInstance().uploadGoalExecution(this.getGoalContext(), this, _before);
 			AbstractGoal.log.info("Uploaded goal execution info");
 		} catch (Exception e) {
 			AbstractGoal.log.error("Error while uploading goal execution info: " + e.getMessage());

--- a/lang/src/main/java/com/sap/psr/vulas/goals/BomGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/BomGoal.java
@@ -52,7 +52,7 @@ public class BomGoal extends AbstractAppGoal {
 				t.setSearchPaths(this.getAppPaths());
 				t.setGoalClient(this.getGoalClient());
 				t.setKnownDependencies(this.getKnownDependencies());
-				t.configure();
+				t.configure(this.getConfiguration());
 
 				// Execute
 				t.execute();
@@ -82,8 +82,8 @@ public class BomGoal extends AbstractAppGoal {
 				final Library lib = dep.getLib();
 				if(lib!=null) {
 					if(lib.hasValidDigest()) {
-						BackendConnector.getInstance().uploadLibrary(lib);
-						if(CoreConfiguration.isJarUploadEnabled())
+						BackendConnector.getInstance().uploadLibrary(this.getGoalContext(), lib);
+						if(CoreConfiguration.isJarUploadEnabled(this.getGoalContext().getVulasConfiguration()))
 							BackendConnector.getInstance().uploadLibraryFile(lib.getDigest(), Paths.get(dep.getPath()));
 					}
 					else {

--- a/lang/src/main/java/com/sap/psr/vulas/goals/GoalContext.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/GoalContext.java
@@ -7,6 +7,7 @@ import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.json.model.Space;
 import com.sap.psr.vulas.shared.json.model.Tenant;
 import com.sap.psr.vulas.shared.util.Constants;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 /**
  * Represents the context of a goal execution. All its elements can be specified using
@@ -31,6 +32,8 @@ public class GoalContext implements Serializable {
 	private Space space = null;
 
 	private Application application = null;
+	
+	private VulasConfiguration vulasConfiguration = null;
 
 	public boolean hasTenant() { return this.tenant!=null; }
 	public Tenant getTenant() { return this.tenant; }
@@ -43,7 +46,10 @@ public class GoalContext implements Serializable {
 	public boolean hasApplication() { return this.application!=null; }
 	public Application getApplication() { return this.application; }
 	public void setApplication(Application _a) { this.application = _a; }
-
+	
+	public VulasConfiguration getVulasConfiguration() { return vulasConfiguration; }
+	public void setVulasConfiguration(VulasConfiguration vulasConfiguration) { this.vulasConfiguration = vulasConfiguration; }
+	
 	@Override
 	public String toString() {
 		final StringBuffer b = new StringBuffer();

--- a/lang/src/main/java/com/sap/psr/vulas/goals/GoalContext.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/GoalContext.java
@@ -33,7 +33,7 @@ public class GoalContext implements Serializable {
 
 	private Application application = null;
 	
-	private VulasConfiguration vulasConfiguration = null;
+	private transient VulasConfiguration vulasConfiguration = null;
 
 	public boolean hasTenant() { return this.tenant!=null; }
 	public Tenant getTenant() { return this.tenant; }

--- a/lang/src/main/java/com/sap/psr/vulas/goals/UploadGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/UploadGoal.java
@@ -1,6 +1,7 @@
 package com.sap.psr.vulas.goals;
 
 import com.sap.psr.vulas.backend.BackendConnector;
+import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.enums.GoalType;
 
 public class UploadGoal extends AbstractAppGoal {
@@ -9,6 +10,6 @@ public class UploadGoal extends AbstractAppGoal {
 
 	@Override
 	protected void executeTasks() throws Exception {
-		BackendConnector.getInstance().batchUpload();
+		BackendConnector.getInstance().batchUpload(this.getGoalContext().getVulasConfiguration().getDir(CoreConfiguration.UPLOAD_DIR));
 	}
 }

--- a/lang/src/main/java/com/sap/psr/vulas/goals/UploadGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/UploadGoal.java
@@ -1,7 +1,6 @@
 package com.sap.psr.vulas.goals;
 
 import com.sap.psr.vulas.backend.BackendConnector;
-import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.enums.GoalType;
 
 public class UploadGoal extends AbstractAppGoal {
@@ -10,6 +9,6 @@ public class UploadGoal extends AbstractAppGoal {
 
 	@Override
 	protected void executeTasks() throws Exception {
-		BackendConnector.getInstance().batchUpload(this.getGoalContext().getVulasConfiguration().getDir(CoreConfiguration.UPLOAD_DIR));
+		BackendConnector.getInstance().batchUpload(this.getGoalContext());
 	}
 }

--- a/lang/src/main/java/com/sap/psr/vulas/report/Report.java
+++ b/lang/src/main/java/com/sap/psr/vulas/report/Report.java
@@ -323,12 +323,12 @@ public class Report {
 		this.context.put("obsoleteExemptionsSignatureNotPresent", StringUtil.join(obsolSignNotPresent, ", "));
 
 		// Basic info
-		this.context.put("vulas-backend-serviceUrl", VulasConfiguration.getGlobal().getServiceUrl(Service.BACKEND));
-		this.context.put("vulas-cia-serviceUrl", VulasConfiguration.getGlobal().getServiceUrl(Service.CIA));
+		this.context.put("vulas-backend-serviceUrl", this.goalContext.getVulasConfiguration().getServiceUrl(Service.BACKEND));
+		this.context.put("vulas-cia-serviceUrl", this.goalContext.getVulasConfiguration().getServiceUrl(Service.CIA));
 		this.context.put("app", app);
 		this.context.put("projects", modules);
 		this.context.put("generatedAt", Report.dateFormat.format(new Date()));
-		this.context.put("vulas-shared-homepage", VulasConfiguration.getGlobal().getConfiguration().getString(VulasConfiguration.HOMEPAGE, "undefined"));
+		this.context.put("vulas-shared-homepage", this.goalContext.getVulasConfiguration().getConfiguration().getString(VulasConfiguration.HOMEPAGE, "undefined"));
 		
 		// Configuration
 		this.context.put("exceptionThreshold", this.exceptionThreshold);

--- a/lang/src/main/java/com/sap/psr/vulas/tasks/AbstractTask.java
+++ b/lang/src/main/java/com/sap/psr/vulas/tasks/AbstractTask.java
@@ -11,6 +11,7 @@ import com.sap.psr.vulas.goals.GoalConfigurationException;
 import com.sap.psr.vulas.shared.enums.GoalClient;
 import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.json.model.Dependency;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 public abstract class AbstractTask implements Task {
 	
@@ -23,6 +24,8 @@ public abstract class AbstractTask implements Task {
 	private List<Path> searchPaths = null;
 	
 	private Map<Path, Dependency> knownDependencies = null;
+	
+	protected VulasConfiguration vulasConfiguration = null;
 	
 	// ====================  Setter methods used to passed general context information to the task
 	
@@ -61,7 +64,8 @@ public abstract class AbstractTask implements Task {
 	 * Checks the search {@link Path} and {@link GoalClient}.
 	 */
 	@Override
-	public void configure() throws GoalConfigurationException {
+	public void configure(VulasConfiguration _cfg) throws GoalConfigurationException {
+		this.vulasConfiguration = _cfg;
 		if(!this.hasSearchPath())
 			log.warn("Task " + this + ": No search path specified");
 		if(this.client==null)

--- a/lang/src/main/java/com/sap/psr/vulas/tasks/Task.java
+++ b/lang/src/main/java/com/sap/psr/vulas/tasks/Task.java
@@ -11,6 +11,7 @@ import com.sap.psr.vulas.shared.enums.GoalClient;
 import com.sap.psr.vulas.shared.enums.ProgrammingLanguage;
 import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.json.model.Dependency;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 public interface Task {
 	
@@ -43,7 +44,7 @@ public interface Task {
 	 * Called prior to {@link Task#execute()}.
 	 * @throws GoalConfigurationException
 	 */
-	public void configure() throws GoalConfigurationException;
+	public void configure(VulasConfiguration _cfg) throws GoalConfigurationException;
 	
 	/**
 	 * Performs the actual application analysis.

--- a/lang/src/test/java/com/sap/psr/vulas/goals/AbstractGoalTest.java
+++ b/lang/src/test/java/com/sap/psr/vulas/goals/AbstractGoalTest.java
@@ -19,6 +19,8 @@ public class AbstractGoalTest {
 	protected Tenant testTenant;
 	protected Space testSpace;
 	protected Application testApp;
+	
+	protected VulasConfiguration vulasConfiguration = null;
 
 	/**
 	 * Before every test:
@@ -33,6 +35,8 @@ public class AbstractGoalTest {
 		testTenant = this.buildTestTenant();
 		testSpace = this.buildTestSpace();
 		testApp = this.buildTestApplication();
+		
+		this.vulasConfiguration = new VulasConfiguration();
 	}
 
 	@After
@@ -58,6 +62,6 @@ public class AbstractGoalTest {
 	protected void configureBackendServiceUrl(StubServer _ss) {
 		final StringBuffer b = new StringBuffer();
 		b.append("http://localhost:").append(_ss.getPort()).append("/backend");
-		VulasConfiguration.getGlobal().setProperty(VulasConfiguration.getServiceUrlKey(Service.BACKEND), b.toString());
+		vulasConfiguration.setProperty(VulasConfiguration.getServiceUrlKey(Service.BACKEND), b.toString());
 	}
 }

--- a/lang/src/test/java/com/sap/psr/vulas/goals/BomGoalTest.java
+++ b/lang/src/test/java/com/sap/psr/vulas/goals/BomGoalTest.java
@@ -127,7 +127,7 @@ public class BomGoalTest extends AbstractGoalTest {
 		verifyHttp(server).times(1, 
 				method(Method.PUT),
 				uri("/backend" + PathBuilder.app(this.testApp)));
-		verifyHttp(server).times(2, 
+		verifyHttp(server).times(1, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}
@@ -155,11 +155,11 @@ public class BomGoalTest extends AbstractGoalTest {
 		final AbstractGoal goal = GoalFactory.create(GoalType.APP, GoalClient.CLI);
 		goal.setConfiguration(this.vulasConfiguration).executeSync();
 		
-		// Check the HTTP calls made (1 app PUT, 2 goal exe POST)
+		// Check (some of) the HTTP calls made (1 app PUT, 1 goal exe POST)
 		verifyHttp(server).times(1, 
 				method(Method.PUT),
 				uri("/backend" + PathBuilder.app(this.testApp)));
-		verifyHttp(server).times(2, 
+		verifyHttp(server).times(1, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}

--- a/lang/src/test/java/com/sap/psr/vulas/goals/BomGoalTest.java
+++ b/lang/src/test/java/com/sap/psr/vulas/goals/BomGoalTest.java
@@ -91,15 +91,14 @@ public class BomGoalTest extends AbstractGoalTest {
 		this.setupMockServices(this.testApp);
 
 		// Set config
-		final VulasConfiguration cfg = new VulasConfiguration();
-		cfg.setProperty(CoreConfiguration.TENANT_TOKEN, "foo");
-		cfg.setProperty(CoreConfiguration.APP_CTX_GROUP, this.testApp.getMvnGroup());
-		cfg.setProperty(CoreConfiguration.APP_CTX_ARTIF, this.testApp.getArtifact());
-		cfg.setProperty(CoreConfiguration.APP_CTX_VERSI, null); // Will raise the exception
+		this.vulasConfiguration.setProperty(CoreConfiguration.TENANT_TOKEN, "foo");
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_GROUP, this.testApp.getMvnGroup());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_ARTIF, this.testApp.getArtifact());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_VERSI, null); // Will raise the exception
 
 		// Execute goal
 		final AbstractGoal goal = GoalFactory.create(GoalType.APP, GoalClient.CLI);
-		goal.setConfiguration(cfg).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 	}
 
 	/**
@@ -115,15 +114,14 @@ public class BomGoalTest extends AbstractGoalTest {
 		this.setupMockServices(this.testApp);
 
 		// Set config
-		final VulasConfiguration cfg = new VulasConfiguration();
-		cfg.setProperty(CoreConfiguration.TENANT_TOKEN, "foo");
-		cfg.setProperty(CoreConfiguration.APP_CTX_GROUP, this.testApp.getMvnGroup());
-		cfg.setProperty(CoreConfiguration.APP_CTX_ARTIF, this.testApp.getArtifact());
-		cfg.setProperty(CoreConfiguration.APP_CTX_VERSI, this.testApp.getVersion());
+		this.vulasConfiguration.setProperty(CoreConfiguration.TENANT_TOKEN, "foo");
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_GROUP, this.testApp.getMvnGroup());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_ARTIF, this.testApp.getArtifact());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_VERSI, this.testApp.getVersion());
 
 		// Execute goal
 		final AbstractGoal goal = GoalFactory.create(GoalType.APP, GoalClient.CLI);
-		goal.setConfiguration(cfg).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 
 		// Check the HTTP calls made
 		verifyHttp(server).times(1, 
@@ -147,16 +145,15 @@ public class BomGoalTest extends AbstractGoalTest {
 		this.setupMockServices(this.testApp);
 
 		// Set config
-		final VulasConfiguration cfg = new VulasConfiguration();
-		cfg.setProperty(CoreConfiguration.TENANT_TOKEN, "foo");
-		cfg.setProperty(CoreConfiguration.APP_CTX_GROUP, this.testApp.getMvnGroup());
-		cfg.setProperty(CoreConfiguration.APP_CTX_ARTIF, this.testApp.getArtifact());
-		cfg.setProperty(CoreConfiguration.APP_CTX_VERSI, this.testApp.getVersion());
-		cfg.setProperty(CoreConfiguration.APP_UPLOAD_EMPTY, new Boolean(true));
+		this.vulasConfiguration.setProperty(CoreConfiguration.TENANT_TOKEN, "foo");
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_GROUP, this.testApp.getMvnGroup());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_ARTIF, this.testApp.getArtifact());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_VERSI, this.testApp.getVersion());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_UPLOAD_EMPTY, new Boolean(true));
 				
 		// Execute goal
 		final AbstractGoal goal = GoalFactory.create(GoalType.APP, GoalClient.CLI);
-		goal.setConfiguration(cfg).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 		
 		// Check the HTTP calls made (1 app PUT, 2 goal exe POST)
 		verifyHttp(server).times(1, 

--- a/lang/src/test/java/com/sap/psr/vulas/goals/CleanGoalTest.java
+++ b/lang/src/test/java/com/sap/psr/vulas/goals/CleanGoalTest.java
@@ -112,7 +112,7 @@ public class CleanGoalTest extends AbstractGoalTest {
 		verifyHttp(server).times(1, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.app(this.testApp)));
-		verifyHttp(server).times(4, 
+		verifyHttp(server).times(2, 
 				method(Method.POST),
 				uri("/backend" + PathBuilder.goalExcecutions(null, null, this.testApp)));
 	}

--- a/lang/src/test/java/com/sap/psr/vulas/goals/CleanGoalTest.java
+++ b/lang/src/test/java/com/sap/psr/vulas/goals/CleanGoalTest.java
@@ -91,20 +91,19 @@ public class CleanGoalTest extends AbstractGoalTest {
 		this.setupMockServices(this.testApp);
 
 		// Set config
-		final VulasConfiguration cfg = new VulasConfiguration();
-		cfg.setProperty(CoreConfiguration.TENANT_TOKEN, "foo");
-		cfg.setProperty(CoreConfiguration.APP_CTX_GROUP, this.testApp.getMvnGroup());
-		cfg.setProperty(CoreConfiguration.APP_CTX_ARTIF, this.testApp.getArtifact());
-		cfg.setProperty(CoreConfiguration.APP_CTX_VERSI, this.testApp.getVersion());
-		cfg.setProperty(CoreConfiguration.APP_UPLOAD_EMPTY, new Boolean(true));
+		this.vulasConfiguration.setProperty(CoreConfiguration.TENANT_TOKEN, "foo");
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_GROUP, this.testApp.getMvnGroup());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_ARTIF, this.testApp.getArtifact());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_CTX_VERSI, this.testApp.getVersion());
+		this.vulasConfiguration.setProperty(CoreConfiguration.APP_UPLOAD_EMPTY, new Boolean(true));
 				
 		// APP
 		AbstractGoal goal = GoalFactory.create(GoalType.APP, GoalClient.CLI);
-		goal.setConfiguration(cfg).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 		
 		// CLEAN
 		goal = GoalFactory.create(GoalType.CLEAN, GoalClient.CLI);
-		goal.setConfiguration(cfg).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 		
 		// Check the HTTP calls made (1 app PUT, 1 app POST, 4 goal exe POST)
 		verifyHttp(server).times(1, 

--- a/lang/src/test/java/com/sap/psr/vulas/goals/SpaceDelGoalTest.java
+++ b/lang/src/test/java/com/sap/psr/vulas/goals/SpaceDelGoalTest.java
@@ -79,23 +79,16 @@ public class SpaceDelGoalTest extends AbstractGoalTest {
 			.post("/backend" + PathBuilder.goalExcecutions(null, _s, null));
 	}
 
-	/**
-	 * Two HTTP requests made for space creation and goal execution creation
-	 * 
-	 * @throws GoalConfigurationException
-	 * @throws GoalExecutionException
-	 */
 	@Test
 	public void testDelSpace() throws GoalConfigurationException, GoalExecutionException {
 		// Mock REST services
 		this.configureBackendServiceUrl(server);
 		this.setupMockServices(this.testTenant, this.testSpace);
-				
-		final VulasConfiguration cfg = new VulasConfiguration();
-		cfg.setProperty(CoreConfiguration.TENANT_TOKEN, testTenant.getTenantToken());
-		cfg.setProperty(CoreConfiguration.SPACE_TOKEN, testSpace.getSpaceToken());
+		
+		this.vulasConfiguration.setProperty(CoreConfiguration.TENANT_TOKEN, testTenant.getTenantToken());
+		this.vulasConfiguration.setProperty(CoreConfiguration.SPACE_TOKEN, testSpace.getSpaceToken());
 		
 		final AbstractGoal goal = GoalFactory.create(GoalType.SPACEDEL, GoalClient.CLI);
-		goal.setConfiguration(cfg).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 	}
 }

--- a/lang/src/test/java/com/sap/psr/vulas/goals/SpaceNewGoalTest.java
+++ b/lang/src/test/java/com/sap/psr/vulas/goals/SpaceNewGoalTest.java
@@ -71,7 +71,7 @@ public class SpaceNewGoalTest extends AbstractGoalTest {
 	@Test(expected=GoalExecutionException.class)
 	public void testNewSpaceWithoutTenantConfiguration() throws GoalConfigurationException, GoalExecutionException {
 		final AbstractGoal goal = GoalFactory.create(GoalType.SPACENEW, GoalClient.CLI);
-		goal.setConfiguration(new VulasConfiguration()).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 	}
 
 	/**
@@ -82,10 +82,9 @@ public class SpaceNewGoalTest extends AbstractGoalTest {
 	 */
 	@Test(expected=GoalExecutionException.class)
 	public void testNewSpaceWithoutBackendConfiguration() throws GoalConfigurationException, GoalExecutionException {
-		final VulasConfiguration cfg = new VulasConfiguration();
-		cfg.setProperty(CoreConfiguration.TENANT_TOKEN, testTenant.getTenantToken());		
+		this.vulasConfiguration.setProperty(CoreConfiguration.TENANT_TOKEN, testTenant.getTenantToken());		
 		final AbstractGoal goal = GoalFactory.create(GoalType.SPACENEW, GoalClient.CLI);
-		goal.setConfiguration(cfg).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 	}
 
 	/**
@@ -101,14 +100,13 @@ public class SpaceNewGoalTest extends AbstractGoalTest {
 		this.setupMockSpaceServices(testSpace);
 
 		// Set config
-		final VulasConfiguration cfg = new VulasConfiguration();
-		cfg.setProperty(CoreConfiguration.TENANT_TOKEN, testTenant.getTenantToken());
-		cfg.setProperty(CoreConfiguration.SPACE_NAME, testSpace.getSpaceName());
-		cfg.setProperty(CoreConfiguration.SPACE_DESCR, testSpace.getSpaceDescription());
+		this.vulasConfiguration.setProperty(CoreConfiguration.TENANT_TOKEN, testTenant.getTenantToken());
+		this.vulasConfiguration.setProperty(CoreConfiguration.SPACE_NAME, testSpace.getSpaceName());
+		this.vulasConfiguration.setProperty(CoreConfiguration.SPACE_DESCR, testSpace.getSpaceDescription());
 
 		// Execute goal
 		final AbstractGoal goal = GoalFactory.create(GoalType.SPACENEW, GoalClient.CLI);
-		goal.setConfiguration(cfg).executeSync();
+		goal.setConfiguration(this.vulasConfiguration).executeSync();
 		
 		final Space new_space = (Space)goal.getResultObject();
 		assertEquals(testSpace, new_space);

--- a/lang/src/test/java/com/sap/psr/vulas/report/ReportTest.java
+++ b/lang/src/test/java/com/sap/psr/vulas/report/ReportTest.java
@@ -89,9 +89,10 @@ public class ReportTest extends AbstractGoalTest {
 			this.configureBackendServiceUrl(server);
 			this.setupMockServices(this.testApp);
 
-			final Configuration cfg = VulasConfiguration.getGlobal().getConfiguration();
+			final Configuration cfg = vulasConfiguration.getConfiguration();
 
 			final GoalContext goal_context = new GoalContext();
+			goal_context.setVulasConfiguration(vulasConfiguration);
 			goal_context.setTenant(this.testTenant);
 			goal_context.setSpace(this.testSpace);
 			goal_context.setApplication(this.testApp);

--- a/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/AbstractVulasSpaceMojo.java
+++ b/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/AbstractVulasSpaceMojo.java
@@ -46,6 +46,9 @@ public abstract class AbstractVulasSpaceMojo extends AbstractMojo {
 
 	protected AbstractSpaceGoal goal = null;
 
+	/** The configuration used throughout the execution of the goal. */
+    protected VulasConfiguration vulasConfiguration = new VulasConfiguration();
+    
 	/**
 	 * Puts the plugin configuration element <layeredConfiguration> as a new layer into {@link VulasConfiguration}.
 	 * If no such element exists, e.g., because the POM file does not contain a plugin section for Vulas, default settings
@@ -55,39 +58,39 @@ public abstract class AbstractVulasSpaceMojo extends AbstractMojo {
 	public final void prepareConfiguration() throws Exception {
 
 		// Delete any transient settings that remaining from a previous goal execution (if any)
-		final boolean contained_values = VulasConfiguration.getGlobal().clearTransientProperties();
+		final boolean contained_values = this.vulasConfiguration.clearTransientProperties();
 		if(contained_values)
 			getLog().info("Transient configuration settings deleted");
 
 		// Get the configuration layer from the plugin configuration (can be null)
-		VulasConfiguration.getGlobal().addLayerAfterSysProps("Plugin configuration", this.layeredConfiguration, null, true);
+		this.vulasConfiguration.addLayerAfterSysProps("Plugin configuration", this.layeredConfiguration, null, true);
 
 		// Check whether the application context can be established
 		Application app = null;
 		try {
-			app = CoreConfiguration.getAppContext();
+			app = CoreConfiguration.getAppContext(this.vulasConfiguration);
 		}
 		// In case the plugin is called w/o using the Vulas profile, project-specific settings are not set
 		// Set them using the project member
 		catch (ConfigurationException e) {
-			VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.APP_CTX_GROUP, this.project.getGroupId());
-			VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.APP_CTX_ARTIF, this.project.getArtifactId());
-			VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.APP_CTX_VERSI, this.project.getVersion());
-			app = CoreConfiguration.getAppContext();
+			this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.APP_CTX_GROUP, this.project.getGroupId());
+			this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.APP_CTX_ARTIF, this.project.getArtifactId());
+			this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.APP_CTX_VERSI, this.project.getVersion());
+			app = CoreConfiguration.getAppContext(this.vulasConfiguration);
 		}
 
 		// Set defaults for all the paths
-		VulasConfiguration.getGlobal().setPropertyIfEmpty(VulasConfiguration.TMP_DIR, 			Paths.get(this.project.getBuild().getDirectory(), "vulas", "tmp").toString());
-		VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.UPLOAD_DIR, 		Paths.get(this.project.getBuild().getDirectory(), "vulas", "upload").toString());
-		VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.INSTR_SRC_DIR, 		Paths.get(this.project.getBuild().getDirectory()).toString());
-		VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.INSTR_TARGET_DIR, 	Paths.get(this.project.getBuild().getDirectory(), "vulas", "target").toString());
-		VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.INSTR_INCLUDE_DIR, 	Paths.get(this.project.getBuild().getDirectory(), "vulas", "include").toString());
-		VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.INSTR_LIB_DIR, 		Paths.get(this.project.getBuild().getDirectory(), "vulas", "lib").toString());
-		VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.REP_DIR, 			Paths.get(this.project.getBuild().getDirectory(), "vulas", "report").toString());
+		this.vulasConfiguration.setPropertyIfEmpty(VulasConfiguration.TMP_DIR, 			Paths.get(this.project.getBuild().getDirectory(), "vulas", "tmp").toString());
+		this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.UPLOAD_DIR, 		Paths.get(this.project.getBuild().getDirectory(), "vulas", "upload").toString());
+		this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.INSTR_SRC_DIR, 		Paths.get(this.project.getBuild().getDirectory()).toString());
+		this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.INSTR_TARGET_DIR, 	Paths.get(this.project.getBuild().getDirectory(), "vulas", "target").toString());
+		this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.INSTR_INCLUDE_DIR, 	Paths.get(this.project.getBuild().getDirectory(), "vulas", "include").toString());
+		this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.INSTR_LIB_DIR, 		Paths.get(this.project.getBuild().getDirectory(), "vulas", "lib").toString());
+		this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.REP_DIR, 			Paths.get(this.project.getBuild().getDirectory(), "vulas", "report").toString());
 
 		// Read app constructs from src/main/java and target/classes
 		final String p = Paths.get(this.project.getBuild().getOutputDirectory()).toString() + "," + Paths.get(this.project.getBuild().getSourceDirectory()).toString();
-		VulasConfiguration.getGlobal().setPropertyIfEmpty(CoreConfiguration.APP_DIRS, p);
+		this.vulasConfiguration.setPropertyIfEmpty(CoreConfiguration.APP_DIRS, p);
 
 		// Test how-to get the reactor POM in a reliable manner
 
@@ -108,7 +111,7 @@ public abstract class AbstractVulasSpaceMojo extends AbstractMojo {
 			// Create the goal
 			this.createGoal();
 			this.goal.setGoalClient(GoalClient.MAVEN_PLUGIN);
-			this.goal.setConfiguration(VulasConfiguration.getGlobal());
+			this.goal.setConfiguration(this.vulasConfiguration);
 
 			// Execute the goal
 			this.executeGoal();

--- a/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/MvnPluginInstr.java
+++ b/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/MvnPluginInstr.java
@@ -41,8 +41,8 @@ public class MvnPluginInstr extends AbstractVulasMojo {
 	@Override
 	protected void executeGoal() throws Exception {
 		// Copy the agent JAR into the include folder
-		final Path lib_dir = VulasConfiguration.getGlobal().getDir(CoreConfiguration.INSTR_LIB_DIR);
-		final Path incl_dir = VulasConfiguration.getGlobal().getDir(CoreConfiguration.INSTR_INCLUDE_DIR);
+		final Path lib_dir = this.vulasConfiguration.getDir(CoreConfiguration.INSTR_LIB_DIR);
+		final Path incl_dir = this.vulasConfiguration.getDir(CoreConfiguration.INSTR_INCLUDE_DIR);
 		
 		final Path incl_agent = FileUtil.copyFile(this.getAgentJarFile().toPath(), incl_dir);
 		final Path lib_agent = FileUtil.copyFile(this.getAgentJarFile().toPath(), lib_dir);

--- a/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/VulasAgentMojo.java
+++ b/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/VulasAgentMojo.java
@@ -58,7 +58,7 @@ public class VulasAgentMojo extends AbstractVulasMojo {
 		private final HashMap<String, String> agentOptions = new HashMap<>();
 
 		/**
-		 * Creates the options for Vuals' Java Agent and initializes them with reasonable defaults.
+		 * Creates the options for Vulas' Java Agent and initializes them with reasonable defaults.
 		 */
 		public VulasAgentOptions() {
 			//prepare vulas configuration
@@ -74,7 +74,7 @@ public class VulasAgentMojo extends AbstractVulasMojo {
             }*/
 
 			// Add settings from plugin configuration
-			Configuration configuration = VulasConfiguration.getGlobal().getConfigurationLayer(PLUGIN_CFG_LAYER);
+			Configuration configuration = vulasConfiguration.getConfigurationLayer(PLUGIN_CFG_LAYER);
 			if(configuration!=null) {
 				getLog().info("The following settings are taken from layer [" + PLUGIN_CFG_LAYER + "]:");
 				final Iterator<String> iter = configuration.getKeys(); 
@@ -97,7 +97,7 @@ public class VulasAgentMojo extends AbstractVulasMojo {
 			}
 			
 			// Add settings from sys properties
-			configuration = VulasConfiguration.getGlobal().getConfigurationLayer(VulasConfiguration.SYS_PROP_CFG_LAYER);
+			configuration = vulasConfiguration.getConfigurationLayer(VulasConfiguration.SYS_PROP_CFG_LAYER);
 			if(configuration!=null) {
 				getLog().info("The following settings are taken from layer [" + VulasConfiguration.SYS_PROP_CFG_LAYER + "]:");
 				final Iterator<String> iter = configuration.getKeys(); 
@@ -246,8 +246,8 @@ public class VulasAgentMojo extends AbstractVulasMojo {
 	 * @return the name of the property to modify
 	 */
 	private String getEffectivePropertyName() {
-		if(!VulasConfiguration.getGlobal().isEmpty(PROPERTY_NAME)) {
-			return VulasConfiguration.getGlobal().getConfiguration().getString(PROPERTY_NAME);
+		if(!this.vulasConfiguration.isEmpty(PROPERTY_NAME)) {
+			return this.vulasConfiguration.getConfiguration().getString(PROPERTY_NAME);
 		}
 		else if(isEclipseTestPluginPackaging()) {
 			return TYCHO_ARG_LINE;

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.5.6</version>
+				<version>4.5.7</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-cli</groupId>
@@ -227,29 +227,29 @@
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.23.1-GA</version>
+				<version>3.24.1-GA</version>
 			</dependency>
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-runtime</artifactId>
-				<version>4.7.1</version>
+				<version>4.7.2</version>
 			</dependency>
 
 			<!-- Versions of 'com.fasterxml.jackson.core' artifacts should be identical -->
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
-				<version>2.9.7</version>
+				<version>2.9.8</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.9.7</version>
+				<version>2.9.8</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.9.7</version>
+				<version>2.9.8</version>
 			</dependency>
 
 			<!-- Versions of 'org.apache.maven' artifacts should be identical -->
@@ -418,7 +418,7 @@
 						<dependency>
 							<groupId>org.apache.maven.wagon</groupId>
 							<artifactId>wagon-file</artifactId>
-							<version>3.2.0</version>
+							<version>3.3.1</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/FileUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/FileUtil.java
@@ -259,7 +259,8 @@ public class FileUtil {
 	 * Writes a {@link String} to the given {@link File}.
 	 */
 	public static final void writeToFile(File _f, String _content) throws IOException {
-		FileUtil.writeToFile(_f, _content.getBytes(FileUtil.getCharset()));
+		if(_content!=null)
+			FileUtil.writeToFile(_f, _content.getBytes(FileUtil.getCharset()));
 	}
 
 	/**
@@ -351,8 +352,8 @@ public class FileUtil {
 
 			// Digest preparation
 			final MessageDigest md = MessageDigest.getInstance(_alg.toString());				
-			try (final InputStream is = new FileInputStream(_file)) {
-				final DigestInputStream dis = new DigestInputStream(is, md);
+			try (final InputStream is = new FileInputStream(_file);
+				 final DigestInputStream dis = new DigestInputStream(is, md);) {
 				byte[] bytes = new byte[1024];
 				while(dis.read(bytes, 0, 1024)!=-1) {;} //read()
 				byte[] digest = md.digest();

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/StringUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/StringUtil.java
@@ -24,8 +24,9 @@ public class StringUtil {
 	public static final long MILLI_IN_MIN = 60L * 1000L;
 
 	public static final long NANOS_IN_MIN = 60L * 1000L * 1000L *1000L;
-
-	private static final DateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+	
+	private static final String FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+	private static final SimpleDateFormat FORMAT = new SimpleDateFormat(FORMAT_STRING);
 
 	public static final String formatMinString(double _d) { return String.format("[%7.1f min]", _d); }
 	public static final String formatMinString(long _n) { return formatMinString((double)_n/(double)MILLI_IN_MIN); }
@@ -57,7 +58,7 @@ public class StringUtil {
 	 */
 	public static final String byteToMBString(long _bytes)   { return formatMBString((double)_bytes/(double)MEGABYTE); }
 
-	public static final String formatDate(long _ms) { return FORMAT.format(new Date(_ms)); }
+	public static final synchronized String formatDate(long _ms) { return FORMAT.format(new Date(_ms)); }
 
 	/**
 	 * Use {@link StringUtil#nanoToFlexDurationString(long)} instead.

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/ThreadUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/ThreadUtil.java
@@ -13,23 +13,32 @@ public class ThreadUtil {
 	 * Returns true if the value of configuration setting {@link NO_OF_THREADS} is equal to AUTO, false otherwise.
 	 * @return
 	 */
-	public static boolean isAutoThreading() {
-		return "AUTO".equalsIgnoreCase(VulasConfiguration.getGlobal().getConfiguration().getString(NO_OF_THREADS, null));
+	private static boolean isAutoThreading(VulasConfiguration _cfg) {
+		return "AUTO".equalsIgnoreCase(_cfg.getConfiguration().getString(NO_OF_THREADS, null));
 	}
-
+	
 	/**
 	 * Returns the number of threads to be used for parallelized processing steps, thereby taking the configuration setting
 	 * {@link NO_OF_THREADS} and the number of cores into account.
 	 * @return
 	 */
-	public static int getNoThreads(final int _multiply_if_auto) {
+	public static final int getNoThreads(final int _multiply_if_auto) {
+		return getNoThreads(VulasConfiguration.getGlobal(), _multiply_if_auto);
+	}
+	
+	/**
+	 * Returns the number of threads to be used for parallelized processing steps, thereby taking the configuration setting
+	 * {@link NO_OF_THREADS} and the number of cores into account.
+	 * @return
+	 */
+	public static final int getNoThreads(final VulasConfiguration _cfg, final int _multiply_if_auto) {
 		int number = 1;
-		if(isAutoThreading()) {
+		if(isAutoThreading(_cfg)) {
 			number = Runtime.getRuntime().availableProcessors() * _multiply_if_auto;
 			log.info("Auto-threading enabled: Number of threads is [" + _multiply_if_auto + " x " + Runtime.getRuntime().availableProcessors() + " cores]");
 		}
 		else {
-			final String value = VulasConfiguration.getGlobal().getConfiguration().getString(NO_OF_THREADS, "1");
+			final String value = _cfg.getConfiguration().getString(NO_OF_THREADS, "1");
 			try {
 				number = Integer.parseInt(value);
 				log.info("Auto-threading disabled: Number of threads is [" + number + "]");

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
@@ -72,7 +72,7 @@ import com.sap.psr.vulas.shared.connectivity.ServiceConnectionException;
 public class VulasConfiguration {
 
 	private static Log log = null;
-	private static final Log getLog() {
+	private static final synchronized Log getLog() {
 		if(VulasConfiguration.log==null)
 			VulasConfiguration.log = LogFactory.getLog(VulasConfiguration.class);
 		return VulasConfiguration.log;

--- a/shared/src/test/java/com/sap/psr/vulas/shared/util/FileUtilTest.java
+++ b/shared/src/test/java/com/sap/psr/vulas/shared/util/FileUtilTest.java
@@ -29,7 +29,8 @@ public class FileUtilTest {
 	
 	@Test
 	public void testGetCharset() {
-		VulasConfiguration.getGlobal().setProperty(VulasConfiguration.CHARSET, "foo");
+		final VulasConfiguration cfg = new VulasConfiguration();
+		cfg.setProperty(VulasConfiguration.CHARSET, "foo");
 		final Charset cs = FileUtil.getCharset();
 		assertEquals("UTF-8", cs.name());
 	}
@@ -37,8 +38,10 @@ public class FileUtilTest {
 	@Test
 	public void testCopyFile() {
 		try {
+			final VulasConfiguration cfg = new VulasConfiguration();
+			final Path tmp_dir = cfg.getTmpDir();
 			final Path source_file = Paths.get("./src/test/resources/Outer.jar");
-			final Path target_file = FileUtil.copyFile(source_file, VulasConfiguration.getGlobal().getTmpDir());
+			final Path target_file = FileUtil.copyFile(source_file, tmp_dir);
 			assertEquals(FileUtil.getDigest(source_file.toFile(), DigestAlgorithm.SHA1), FileUtil.getDigest(target_file.toFile(), DigestAlgorithm.SHA1));
 		} catch (IOException e) {
 			e.printStackTrace();


### PR DESCRIPTION
Main changes are as follows:
- Some classes have been changed as to receive a given instance of `VulasConfiguration` rather than getting the "global" instance using `VulasConfiguration.getGlobal`. This given instance is created early in the goal execution and passed on all the way to the `BackendConnector` and the different `*Request` classes.
- The `AbstractAppGoal` checks whether a given space exists. If not, the goal execution is aborted (fixes #92)

Besides the JUnit tests, I tested the changes running ` mvn -Dvulas vulas:clean vulas:app vulas:a2c vulas:prepare-vulas-agent test vulas:upload vulas:t2c` on the Java test application.