### PR TITLE
Fixed bug in *HttpRequest* classes related to obtaining the VulasConfiguration

### DIFF
--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/BasicHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/BasicHttpRequest.java
@@ -144,8 +144,8 @@ public class BasicHttpRequest extends AbstractHttpRequest {
 			// Make call if one of the following holds:
 			// - call is read request and connect is not offline
 			// - call is write request, exception is null and connect is read_write
-			if( (!this.isUploadRequest() && !CoreConfiguration.isBackendOffline(this.context.getVulasConfiguration()) ) ||
-				(this.isUploadRequest() && exception==null && CoreConfiguration.isBackendReadWrite(this.context.getVulasConfiguration())) ) {
+			if( (!this.isUploadRequest() && !CoreConfiguration.isBackendOffline(this.getVulasConfiguration()) ) ||
+				(this.isUploadRequest() && exception==null && CoreConfiguration.isBackendReadWrite(this.getVulasConfiguration())) ) {
 				try {
 					response = this.sendRequest();
 
@@ -171,7 +171,7 @@ public class BasicHttpRequest extends AbstractHttpRequest {
 
 			// Save to disk if
 			// - call is write request and exception is not null or connect is not read_write
-			if(this.isUploadRequest() && !this.isPayloadSavedOnDisk() && (exception!=null || !CoreConfiguration.isBackendReadWrite(this.context.getVulasConfiguration()))) {
+			if(this.isUploadRequest() && !this.isPayloadSavedOnDisk() && (exception!=null || !CoreConfiguration.isBackendReadWrite(this.getVulasConfiguration()))) {
 				try {
 					this.saveToDisk();
 				} catch (IOException e) {
@@ -459,13 +459,13 @@ public class BasicHttpRequest extends AbstractHttpRequest {
 	public URI getUri(Service _service, String _path, Map<String,String> _params) {
 
 		// Check whether URL is present
-		if(!CoreConfiguration.isBackendOffline(this.context.getVulasConfiguration()) && !this.context.getVulasConfiguration().hasServiceUrl(_service))
+		if(!CoreConfiguration.isBackendOffline(this.getVulasConfiguration()) && !this.getVulasConfiguration().hasServiceUrl(_service))
 			throw new IllegalStateException("URL for service [" + _service + "] is not configured");
 
 		URI uri = null;
 
 		final StringBuilder builder = new StringBuilder();
-		builder.append(this.context.getVulasConfiguration().getServiceUrl(_service));
+		builder.append(this.getVulasConfiguration().getServiceUrl(_service));
 		builder.append(_path);
 		int i = 0;
 		if(_params!=null) {

--- a/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
+++ b/lang/src/main/java/com/sap/psr/vulas/backend/requests/ConditionalHttpRequest.java
@@ -57,7 +57,7 @@ public class ConditionalHttpRequest extends BasicHttpRequest {
 			throw new IllegalStateException("No condition request or no conditions set");
 
 		// Conditional requests will be skipped in offline mode
-		if(CoreConfiguration.isBackendOffline(this.context.getVulasConfiguration())) {
+		if(CoreConfiguration.isBackendOffline(this.getVulasConfiguration())) {
 			ConditionalHttpRequest.log.info("Condition(s) not evaluated due to offline mode, do " + this.toString());
 			return super.send();
 		}


### PR DESCRIPTION
The `*HttpRequest*` classes can be run within or outside the context of analysis goals. In the latter case, the configuration should be obtained with `VulasConfiguration.getGlobal()`, which did not happen.