### PR TITLE
Change Soot Dependency to Maven Central

### DIFF
--- a/lang-java-reach-soot/pom.xml
+++ b/lang-java-reach-soot/pom.xml
@@ -28,10 +28,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>ca.mcgill.sable</groupId>
-            <artifactId>soot</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
-            <scope>compile</scope>
+          <groupId>ca.mcgill.sable</groupId>
+          <artifactId>soot</artifactId>
+          <version>3.3.0</version>
+          <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.tud.sse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,12 +114,6 @@
 				<module>lang-java-reach-soot</module>
 				<module>lang-java-reach-soot-init</module>
 			</modules>
-			<repositories>
-				<repository>
-					<id>soot</id>
-					<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url><!-- Alternative: soot-snapshot -->
-				</repository>
-			</repositories>
 		</profile>
 
 		<profile>


### PR DESCRIPTION
This PR changes the dependency on the static analysis framework **Soot**, hosted on the Paderborn University Nexus, to the Soot version hosted on Maven Central.

https://search.maven.org/artifact/ca.mcgill.sable/soot/3.3.0/jar