### PR TITLE
Fixed instr(umentation) goal

### DIFF
--- a/lang-java/src/main/java/com/sap/psr/vulas/java/WarAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/WarAnalyzer.java
@@ -25,7 +25,9 @@ import com.sap.psr.vulas.FileAnalysisException;
 import com.sap.psr.vulas.FileAnalyzer;
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.monitor.ClassVisitor;
+import com.sap.psr.vulas.shared.connectivity.Service;
 import com.sap.psr.vulas.shared.util.FileSearch;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 import javassist.CannotCompileException;
 import javassist.CtClass;
@@ -40,6 +42,9 @@ import javassist.NotFoundException;
 public class WarAnalyzer extends JarAnalyzer {
 
 	private static final Log log = LogFactory.getLog(WarAnalyzer.class);
+	
+	private static final String INCL_SPACE = "vulas.core.instr.static.inclSpace";
+	private static final String INCL_BACKEND_URL = "vulas.core.instr.static.inclBackendUrl";
 
 	//	private static final ClassPool CLASSPOOL = ClassPool.getDefault();
 	//	/**
@@ -387,6 +392,15 @@ public class WarAnalyzer extends JarAnalyzer {
 				cfg.setProperty(CoreConfiguration.APP_CTX_GROUP, JarAnalyzer.getAppContext().getMvnGroup());
 				cfg.setProperty(CoreConfiguration.APP_CTX_ARTIF, JarAnalyzer.getAppContext().getArtifact());
 				cfg.setProperty(CoreConfiguration.APP_CTX_VERSI, JarAnalyzer.getAppContext().getVersion());
+				
+				// Include space
+				if(VulasConfiguration.getGlobal().getConfiguration().getBoolean(INCL_SPACE, true) && VulasConfiguration.getGlobal().getConfiguration().containsKey(CoreConfiguration.SPACE_TOKEN))
+					cfg.setProperty(CoreConfiguration.SPACE_TOKEN, VulasConfiguration.getGlobal().getConfiguration().getString(CoreConfiguration.SPACE_TOKEN));
+				
+				// Include backend URL
+				if(VulasConfiguration.getGlobal().getConfiguration().getBoolean(INCL_BACKEND_URL, true) && VulasConfiguration.getGlobal().getConfiguration().containsKey(VulasConfiguration.getServiceUrlKey(Service.BACKEND)))
+					cfg.setProperty(VulasConfiguration.getServiceUrlKey(Service.BACKEND), VulasConfiguration.getGlobal().getConfiguration().getString(VulasConfiguration.getServiceUrlKey(Service.BACKEND)));
+				
 				tmp_file = Files.createTempFile("vulas-core-", ".properties");
 				cfg.save(tmp_file.toFile());
 				is = new FileInputStream(tmp_file.toFile());						

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/goals/InstrGoal.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/goals/InstrGoal.java
@@ -65,7 +65,7 @@ public class InstrGoal extends AbstractAppGoal {
 	public void addInstrPath(Path _p) throws IllegalArgumentException {
 		if(!FileUtil.isAccessibleDirectory(_p) && !FileUtil.isAccessibleFile(_p))
 			log.warn("[" + _p + "] is not an accessible file or directory");
-		else if(this.getAppPaths().contains(_p))
+		else if(this.getInstrPaths().contains(_p))
 			log.debug("[" + _p + "] is already part of intrumentation paths, and will not be added another time");
 		else
 			this.instrPaths.add(_p);
@@ -142,7 +142,7 @@ public class InstrGoal extends AbstractAppGoal {
 		final JarAnalysisManager mgr = new JarAnalysisManager(no_threads, true, app);
 		mgr.setRename(true);
 
-		// Set the different lib, include and work directories (if any)
+		// Set the lib, include and work directories (if any)
 		//if(this.inclPathsFileUtil.isAccessibleDirectory(includeDir) && this.app.getPackaging().toLowerCase().equals("war"))
 		if(this.hasInclPath())
 			mgr.setIncludeDir(this.inclPath);

--- a/lang-java/src/main/resources/vulas-java.properties
+++ b/lang-java/src/main/resources/vulas-java.properties
@@ -7,13 +7,13 @@ vulas.core.jarAnalysis.poolSize = 4
 # Default:
 #   CLI: -
 # Note: Ignored when running the Maven plugin. In all other cases it avoids the separation of application and dependency JARs into distinct folders
-vulas.core.app.appPrefixes = 
+#vulas.core.app.appPrefixes = 
 
 # Regex that identifies JARs with application code (multiple values to be separated by comma) 
 # Default:
 #   CLI: -
 # Note: Ignored when running the Maven plugin. In all other cases it avoids the separation of application and dependency JARs into distinct folders
-vulas.core.app.appJarNames =
+#vulas.core.app.appJarNames =
 
 
 
@@ -49,7 +49,7 @@ vulas.core.instr.blacklist.jars.ignoreScopes = test, provided
 
 # Constructs of dependencies whose filename matches one of the following regular expressions will not be instrumented (multiple ones to be separated by comma)
 # Default: lang-java-.*\.jar,vulas-core-.*\.jar,surefire-.*\.jar,junit-.*\.jar
-vulas.core.instr.blacklist.jars = lang-java-.*\.jar,vulas-core-.*\.jar,surefire-.*\.jar,junit-.*\.jar,org.jacoco.agent.*\.jar
+vulas.core.instr.blacklist.jars = lang-java-.*\.jar,surefire-.*\.jar,junit-.*\.jar,org.jacoco.agent.*\.jar
 
 # User-provided blacklist: Constructs of dependencies whose filename matches one of the following regular expressions will not be instrumented (multiple ones to be separated by comma)
 # Default: -
@@ -80,9 +80,19 @@ vulas.core.instr.whitelist.classloader.acceptChilds = true
 # If true, bytecode and instrumentation code will be written to tmpDir
 vulas.core.instr.writeCode = false
 
+# If true, the workspace will be included in the configuration of rewritten WAR files
+# This can be useful if the setting cannot be passed as system property when starting the container
+# Default: true
+vulas.core.instr.static.inclSpace = true
+
+# If true, the backend URL will be included in the configuration of rewritten WAR files
+# This can be useful if the setting cannot be passed as system property when starting the container
+# Default: true
+vulas.core.instr.static.inclBackendUrl = true
+
 # JARs for which no traces and no archive information will be uploaded (e.g., from Vulas itself)
 # Multiple entries are separated by comma, each entry is a regex
-vulas.core.monitor.blacklist.jars = lang-java-.*\.jar,vulas-core-.*\.jar,surefire-.*\.jar,junit-.*\.jar,org.jacoco.agent.*\.jar
+vulas.core.monitor.blacklist.jars = lang-java-.*\.jar,surefire-.*\.jar,junit-.*\.jar,org.jacoco.agent.*\.jar
 
 # Enables or disables the periodic upload of collected traces to the backend
 # Default: true

--- a/shared/src/test/java/com/sap/psr/vulas/shared/util/VulasConfigurationTest.java
+++ b/shared/src/test/java/com/sap/psr/vulas/shared/util/VulasConfigurationTest.java
@@ -4,10 +4,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -161,5 +166,17 @@ public class VulasConfigurationTest {
 			ce = e;
 		}
 		assertTrue(ce==null);
+	}
+	
+	@Test
+	public void testEscapedUrl() {
+		final VulasConfiguration c1 = new VulasConfiguration();
+		final Properties props = new Properties();
+		try {
+			props.load(new FileInputStream(new File("./src/test/resources/vulas-test.properties")));
+			assertEquals("https://foo.com/bar", props.getProperty("vulas.bar"));
+		} catch (IOException e) {
+			assertTrue(false);
+		}
 	}
 }

--- a/shared/src/test/resources/vulas-test.properties
+++ b/shared/src/test/resources/vulas-test.properties
@@ -1,0 +1,1 @@
+vulas.bar = https:\/\/foo.com\/bar


### PR DESCRIPTION
If `vulas.core.instr.sourceDir` is not set, JARs and WARs to be instrumented will be searched in `vulas.core.app.sourceDir`. Moreover, the configuration settings `vulas.core.space.token` and `vulas.shared.backend.serviceUrl` will be included in `WEB-INF/lib/lang-java-<version>-jar-with-dependencies-and-config.jar$vulas-core.properties` of instrumented WARs.