### PR TITLE
improved version comparisons; fix peval w/o lang

### DIFF
--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/PE_Run.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/PE_Run.java
@@ -29,7 +29,8 @@ public class PE_Run implements Runnable {
 		String[] bugs = VulasConfiguration.getGlobal().getConfiguration().getStringArray(PEConfiguration.BUGID);
 		ProgrammingLanguage lang = null;
 		try{
-			 lang = ProgrammingLanguage.valueOf(VulasConfiguration.getGlobal().getConfiguration().getString(PEConfiguration.LANG));
+			if(VulasConfiguration.getGlobal().getConfiguration().getString(PEConfiguration.LANG)!=null)
+				lang = ProgrammingLanguage.valueOf(VulasConfiguration.getGlobal().getConfiguration().getString(PEConfiguration.LANG));
 		} catch(IllegalArgumentException e){
 			log.error("The specified language value "+VulasConfiguration.getGlobal().getConfiguration().getString(PEConfiguration.LANG)+" is not allowed. Allowed values: PY, JAVA.");
 			return;

--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Version.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Version.java
@@ -94,9 +94,16 @@ public class Version implements Comparable<Version>{
 	 * 	@return 0 if they are equal or contains letters; 1 if this.version>other.version; -1 otherwise
 	 */
 	public int compareNumberVersion(Version other) {
+	
+		Matcher this_m  = VERSION_PATTERN.matcher(this.getVersion());
+		Matcher other_m = VERSION_PATTERN.matcher(other.getVersion());
 
-		String[] varray = this.version.split("\\.");
-		String[] otherVersions = other.getVersion().split("\\.");
+		// Extract the numeric part of the version
+		String this_v = (this_m.matches() ? this_m.group(1) : this.getVersion());
+		String other_v = (other_m.matches() ? other_m.group(1) : other.getVersion());
+
+		String[] varray = this_v.split("\\.");
+		String[] otherVersions = other_v.split("\\.");
 		for(int v=0;v<varray.length&&v<otherVersions.length;v++){
 			if(!varray[v].equals(otherVersions[v])){
 				//check that it only contains numbers
@@ -111,6 +118,7 @@ public class Version implements Comparable<Version>{
 			}
 		}
 		return 0;
+		
 	}
 
 	@Override

--- a/shared/src/test/java/com/sap/psr/vulas/shared/model/generic/VersionTest.java
+++ b/shared/src/test/java/com/sap/psr/vulas/shared/model/generic/VersionTest.java
@@ -14,11 +14,14 @@ public class VersionTest {
 		Version v1 = new Version ("2.2.0.1");
 		Version v2 = new Version ("2.2.1");
 		Version v3 = new Version ("2.2.1.1");
+		Version v4 = new Version ("3.1.18");
+		Version v5 = new Version ("3.1.14-test-05");
 		
 		assertTrue(v0.compareTo(v1)<0);
 		assertTrue(v1.compareTo(v0)>0);
 		assertTrue(v2.compareTo(v1)>0);
 		assertTrue(v3.compareTo(v1)>0);
+		assertTrue(v4.compareTo(v5)>0);
 		
 	}
 


### PR DESCRIPTION
Improved compare numeric versions for Version object to also consider the numeric part before trailing strings (e.g., -xyz) instead of only considering the numeric part before dots separators.

Fixed bug when running patch-lib-analyzer without specified the target language