### PR TITLE
Containers refactor and better experience for users

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   frontend-apps:
     container_name: vulas-os-frontend-apps
     hostname: frontend-apps
-    env_file: .env
     build: 
       context: ./frontend-apps
       dockerfile: ./Dockerfile
@@ -18,7 +17,6 @@ services:
   frontend-bugs:
     container_name: vulas-os-frontend-bugs
     hostname: frontend-bugs
-    env_file: .env
     build: 
       context: ./frontend-bugs
       dockerfile: ./Dockerfile
@@ -46,7 +44,7 @@ services:
       - "8034:7070"
     volumes:
       - "./haproxy/conf/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg"
-    depends_on: 
+    depends_on:
       - frontend-apps
       - frontend-bugs
       - rest-backend
@@ -57,7 +55,6 @@ services:
   patch-lib-analyzer:
     container_name: vulas-os-patch-lib-analyzer
     hostname: patch-lib-analyzer
-    env_file: .env
     build: 
       context: ./patch-lib-analyzer
       dockerfile: ./Dockerfile
@@ -85,12 +82,14 @@ services:
   postgresql:
     container_name: vulas-os-postgresql
     hostname: postgresql
-    env_file: .env
     build: 
       context: ./postgresql
       dockerfile: ./Dockerfile
       args:
         - VULAS_RELEASE=${VULAS_RELEASE}
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
       - "8032:5432"
     volumes:
@@ -101,7 +100,9 @@ services:
   rest-backend:
     container_name: vulas-os-rest-backend
     hostname: rest-backend
-    env_file: .env
+    env_file: 
+      - .env
+      - ./rest-backend/conf/restbackend.properties
     build: 
       context: ./rest-backend    
       dockerfile: ./Dockerfile
@@ -116,6 +117,8 @@ services:
       - vulas.shared.cia.serviceUrl=http://cia:8092/cia
       - vulas.backend.coverageService.langConfidenceThreshold=0.2
       - vulas.backend.coverageService.licenseConfidenceThreshold=0.2
+      - spring.datasource.username=${POSTGRES_USER}
+      - spring.datasource.password=${POSTGRES_PASSWORD}
     links:
       - postgresql:postgresql
       - rest-lib-utils:cia
@@ -129,7 +132,6 @@ services:
   rest-lib-utils:
     container_name: vulas-os-rest-lib-utils
     hostname: rest-lib-utils
-    env_file: .env
     build: 
       context: ./rest-lib-utils 
       dockerfile: ./Dockerfile

--- a/docker/haproxy/Dockerfile
+++ b/docker/haproxy/Dockerfile
@@ -2,6 +2,4 @@ FROM haproxy:alpine
 
 LABEL maintainer="Vulas vulas-dev@listserv.sap.com"
 
-COPY conf/haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
-
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/docker/haproxy/conf/haproxy.cfg
+++ b/docker/haproxy/conf/haproxy.cfg
@@ -1,7 +1,6 @@
 global
     maxconn 2048
     stats socket /var/run/haproxy.sock mode 600 level admin
-    server-state-file /tmp/server_state
 
 defaults
     mode http
@@ -15,9 +14,13 @@ defaults
     # keep server status after reloading
     load-server-state-from-file global
     stats auth "${HAPROXY_STATS_USER}:${HAPROXY_STATS_PASSWORD}"
+    default-server init-addr none
 
 userlist VulasAdmin
     user "${FRONTEND_BUGS_USER}" insecure-password "${FRONTEND_BUGS_PASSWORD}"
+
+resolvers docker_resolver
+    nameserver dns 127.0.0.11:53
 
 frontend http-in
     bind *:8080
@@ -45,10 +48,10 @@ backend frontend-apps-nodes
     balance 	roundrobin
     option 	forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
-    option httpchk get /apps
+    option httpchk GET /apps/ HTTP/1.1\r\nHost:\ haproxy01
     http-check expect ! rstatus ^5
     stats 	enable
-    server 	frontend-apps frontend-apps:8080 check
+    server 	frontend-apps frontend-apps:8080 check resolvers docker_resolver resolve-prefer ipv4
 # --------
 
 # rest-lib-utils
@@ -58,10 +61,10 @@ backend rest-lib-utils-nodes
     balance 	roundrobin
     option 	forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
-    option httpchk get /cia
+    option httpchk GET /cia/ HTTP/1.1\r\nHost:\ haproxy01
     http-check expect ! rstatus ^5
     stats enable
-    server rest-lib-utils rest-lib-utils:8092 check
+    server rest-lib-utils rest-lib-utils:8092 check resolvers docker_resolver resolve-prefer ipv4
 # --------
 
 # rest-backend
@@ -71,10 +74,10 @@ backend rest-backend-nodes
     balance roundrobin
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
-    option httpchk get /backend
+    option httpchk GET /backend/ HTTP/1.1\r\nHost:\ haproxy01
     http-check expect ! rstatus ^5
     stats enable
-    server rest-backend rest-backend:8091 check
+    server rest-backend rest-backend:8091 check resolvers docker_resolver resolve-prefer ipv4
 # --------
 
 # frontend-bugs
@@ -84,10 +87,10 @@ backend frontend-bugs-nodes
     balance roundrobin
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
-    option httpchk get /bugs
+    option httpchk GET /bugs/ HTTP/1.1\r\nHost:\ haproxy01
     http-check expect ! rstatus ^5
     stats enable
-    server frontend-bugs frontend-bugs:8080 check
+    server frontend-bugs frontend-bugs:8080 check resolvers docker_resolver resolve-prefer ipv4
     acl AuthOkay http_auth(VulasAdmin)
     http-request auth realm Vulas if !AuthOkay
 # --------

--- a/docker/rest-backend/conf/restbackend.properties
+++ b/docker/rest-backend/conf/restbackend.properties
@@ -1,0 +1,119 @@
+vulas.backend.cveCache.refetchAllMs=7200000
+vulas.backend.cveCache.refetchSingleMs=10000
+
+# URL to read CVE information from (the placeholder <ID> will be substituted by the actual CVE identifier)
+# Default: -
+vulas.backend.cveCache.serviceUrl=
+
+########## Special workspaces
+
+# Tokens of spaces that cannot be deleted using the REST endpoint
+# Default:
+vulas.backend.space.doNotDelete=
+
+# Tokens of spaces that cannot be cleaned using the REST endpoint
+# Default:
+vulas.backend.space.doNotClean=
+
+# Tokens of spaces that cannot be modified using the REST endpoint
+# Default:
+vulas.backend.space.doNotModify=
+
+
+
+########## Classifier configuration (required by coverage service and browser extensions)
+
+# URL of the ML classifier
+# Default: -
+vulas.shared.cve.serviceUrl=
+
+# URL of the Jira where issues are searched and created
+# Default: -
+vulas.shared.jira.serviceUrl=
+
+# Required for the Jira search API
+# @SAP: id for "OSS Vulnerability Assessment" or "vulas"
+vulas.shared.jira.projectId=
+
+# Required for the Jira search API
+# @SAP: id for "vuln-analysis"
+vulas.shared.jira.componentId=
+
+# Link to open a Jira ticket, the issue id will be appended
+vulas.shared.jira.browseIssueUrl=
+
+# Link to create new Jira tickets, the issue title will be appended
+# Note: The link also contains projectId and componentId
+vulas.shared.jira.createIssueUrl=
+
+
+
+########## Email-related information
+
+# Email subject used when sending a list of all apps as CSV.
+# See: ApplicationController.getApplicationsAsCsv(...)
+# Default: -
+vulas.backend.allApps.mailSubject=
+
+# Sender address used whenever emails are sent
+# Default: -
+vulas.backend.smtp.sender=
+
+# SMTP host
+# Default: -
+vulas.backend.smtp.host=
+
+# SMTP port (smtps=587)
+# Default: -
+vulas.backend.smtp.port=
+
+# SMTP user
+# Default: -
+vulas.backend.smtp.user=
+
+# SMTP password
+# Default: -
+vulas.backend.smtp.pwd=
+
+
+
+########## Frontend customizing
+
+# Comma-separated list of regex to validate distribution lists email addresses
+# Default:
+vulas.backend.frontend.apps.dl.regex=
+
+# Example DL matching the regex
+# Default:
+vulas.backend.frontend.apps.dl.example=
+
+# Label for application software identifier (from external system)
+# Default:
+vulas.backend.frontend.apps.sw.id.label=Software ID
+
+# URL to test for user-submitted sowftware identifiers' validity
+# Default: /swidproxy
+vulas.backend.frontend.apps.sw.id.url=
+
+# Determines whether the software Id should be enforced: if true either sw.id or DL value must be provided.
+# Default:
+vulas.backend.frontend.apps.sw.id.mandatory=false
+
+# Link to wiki about application software identifier
+# Default:
+vulas.backend.frontend.apps.sw.id.link=
+
+# Name of the property used to store the application sofware identifier in the db
+# Default:
+vulas.backend.frontend.apps.sw.id.db.key=
+
+# Regex to validate application software identifier
+# Default:
+vulas.backend.frontend.apps.sw.id.regex=
+
+# Base url to link help pages in the Vulas wiki
+# Default:
+vulas.backend.frontend.apps.wiki.url=https://sap.github.io/vulnerability-assessment-tool/user/
+
+#workaround to make the autothread work until we figure out why the configurations settings inside the shared dependency are not consumed
+vulas.core.noThreads=AUTO

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+echo -e '\n[+] Cleaning old archives'
+
+rm /exporter/**/*.?ar 2> /dev/null
+rm /exporter/client-components/*.?ar 2> /dev/null
+rm /exporter/all-components/*.?ar 2> /dev/null
+
 echo -e "\n[+] Building new archives"
 
 ( set -x; mvn -U -e -Dhttp.proxyHost=${HTTP_PROXY_HOST} -Dhttp.proxyPort=${HTTP_PROXY_PORT} -Dhttps.proxyHost=${HTTPS_PROXY_HOST} -Dhttps.proxyPort=${HTTPS_PROXY_PORT} ${mvn_flags} clean install)
@@ -9,11 +15,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-echo -e '\n[+] Cleaning old archives'
-
-rm /exporter/**/*.?ar 2> /dev/null
-rm /exporter/client-components/*.?ar 2> /dev/null
-
 VULAS_JAVA_BACKEND_COMPONENTS="frontend-apps frontend-bugs patch-lib-analyzer rest-backend rest-lib-utils"
 VULAS_JAVA_CLIENT_COMPONENTS="patch-analyzer cli-scanner plugin-maven"
 VULAS_JAVA_COMPONENTS="cli-scanner frontend-apps frontend-bugs lang-java-reach-wala lang-java-reach lang-java lang-python lang patch-analyzer patch-lib-analyzer plugin-maven repo-client rest-backend rest-lib-utils shared"
@@ -21,6 +22,7 @@ VULAS_JAVA_COMPONENTS="cli-scanner frontend-apps frontend-bugs lang-java-reach-w
 echo -e '\n[+] Copying new archives'
 
 for i in $VULAS_JAVA_BACKEND_COMPONENTS ; do
+    mkdir -p /exporter/$i/
     cp $i/target/*.?ar /exporter/$i/
 done
 

--- a/docs/public/content/admin/index.md
+++ b/docs/public/content/admin/index.md
@@ -1,6 +1,6 @@
 # DevOps
 
-In this tutorial, you will be guided through the necessary steps to set-up the @@PROJECT_NAME@@ backend services.
+In this tutorial you will be guided through the necessary steps to set-up the @@PROJECT_NAME@@ backend services.
 
 <center class='expandable'>
     [![start_page](./img/components.png)](./img/components.png)
@@ -14,8 +14,8 @@ In this tutorial, you will be guided through the necessary steps to set-up the @
 
 ## Pre-requisites
 
-- docker
 - git
+- docker
 
 ## Installation
 
@@ -26,13 +26,6 @@ git clone https://github.com/SAP/vulnerability-assessment-tool
 ```
 
 ### Build Docker images
-
-!!! info "Testing Environment"
-
-    @@PROJECT_NAME@@ was successfully built against
-
-    - Ubuntu 16.04 - Docker version 17.03.2-ce, build f5ec1e2
-    - Win10 noWSL - Docker version 18.01.0-ce, build 03596f5
 
 All the following commands are supposed to be executed from the root folder of the project.
 Before proceeding, be sure to move there with:
@@ -47,11 +40,11 @@ Make a copy of the sample configuration:
 cp docker/.env.sample docker/.env
 ```
 
-Edit the file `docker/.env` to match your needs.
+Customize the file `docker/.env` to match your needs.
 
 !!! info "Sensitive information"
 
-	In `docker/.env` you must configure at least `POSTGRES_USER=` and `spring.datasource.username=` (with equal values), you should also configure the `HAPROXY`'s user and password as well as the credentials to access the bugs' frontend
+	In `docker/.env` you must configure at least `POSTGRES_USER=`, you should also configure the `HAPROXY`'s user and password as well as the credentials to access the bugs' frontend
 
 At this point, you are ready to perform the actual build with the following command:
 
@@ -70,7 +63,7 @@ docker run -it --rm -v ${PWD}/docker:/exporter --env-file ./docker/.env -e mvn_f
 
 In case you are running behind a proxy you need to configure it in the `--build-arg` arguments.
 
-As a result, the folders `docker/<component-name>` will contain compiled JARs (or WARs, depending on the component). The folder `docker/client-tools` will be populated with the JARs for patch-analyzer and cli-scanner.
+As a result, the folders `docker/<component-name>` will contain compiled JARs (or WARs, depending on the component). The folder `docker/client-tools` will be populated with the JARs for client side tools (CLI, plugins, patchanalyzer).
 
 Finally, you may want to make all artifacts available to the developers of your organization (e.g., through an internal Nexus or other artifact distribution system).
 
@@ -82,30 +75,24 @@ You are now ready to run the system:
 (cd docker && docker-compose up -d --build)
 ```
 
-To check that everything started successfully, check the page `http://localhost:8033/haproxy?stats` (user/pwd: `admin/admin`).
-All endpoints should appear as green (you may want to replace `localhost` with the actual hostname of your machine).
+To check if everything started successfully, check the page `http://localhost:8033/haproxy?stats`. All endpoints should appear as green (you may want to replace `localhost` with the actual hostname of your machine).
+
+!!! info "Credentials and start up time"
+    `username` and `password` can be found in your `.env` file, be also advised that `rest-backend` could take more than 30 seconds to be available to answer HTTP requests
 
 ### Populate/maintain the vulnerability database
 
-In order for the tool to detect vulnerabilities, you need to analyze them first so that they are available in the tool's vulnerability database.
+In order for the tool to detect vulnerabilities, you need to import and analyze them first so that they are available in the tool's vulnerability database. Large part of CVE's and bugs are open sourced in [vulnerability-assessment-kb](https://github.com/SAP/vulnerability-assessment-kb).
 
-To do so, please follow the instructions mentioned [here](../vuln_db/tutorials/vuln_db_tutorial).
-
-## Analyze an application
-
-**Pre-requisite**: Please, make sure you take note of the URL of the **backend service** as well as the URL of the **apps Web frontend**, you will need these:
-
-- Apps Web frontend: [http://localhost:8033/apps](https://localhost:8033/apps)
-- Backend service: [http://localhost:8033/backend](http://localhost:8033/backend)
-
-You may want to replace `localhost` with the actual hostname of your machine.
+Follow the instructions mentioned [here](../vuln_db/tutorials/vuln_db_tutorial), to import and build all the vulnerabilities' knowledge.
 
 Get going:
 
-1. Setup your [workspace](../user/manuals/setup/#workspace) (if you don't have one)
-2. Become familiar with the various analysis [goals](../user/manuals/analysis/) (first time users)
-3. Analyze your [Java](../user/tutorials/java_maven) or [Python](../user/tutorials/python_cli) application (on a regular basis)
-4. [Assess](../user/manuals/assess_and_mitigate) findings using the apps Web frontend (following every analysis)
+1. [Import](../vuln_db/tutorials/vuln_db_tutorial) all the CVEs and bugs in your local datababse
+2. Setup your [workspace](../user/manuals/setup/#workspace) (if you don't have one)
+3. Become familiar with the various analysis [goals](../user/manuals/analysis/) (first time users)
+4. Analyze your [Java](../user/tutorials/java_maven) or [Python](../user/tutorials/python_cli) application (on a regular basis)
+5. [Assess](../user/manuals/assess_and_mitigate) findings using the apps Web frontend (following every analysis)
 
 Further links:
 

--- a/frontend-apps/src/main/webapp/view/Master.controller.js
+++ b/frontend-apps/src/main/webapp/view/Master.controller.js
@@ -512,10 +512,12 @@ sap.ui.controller("view.Master", {
 			if (sap.ui.getCore().byId('idSw').getValue() != null && sap.ui.getCore().byId('idSw').getValue() != "") {
 				body = body + ', "properties":[{"source":"USER","name":"' + model.Config.getSwIdDb() + '","value":"' + sap.ui.getCore().byId("idSw").getValue() + '"}]';
 			} else { //alert that SwId id was not provided and they should do it by editing the space
-				sap.m.MessageBox.warning(
-					"You did not provide the " + model.Config.getSwIdLabel() +
-					" Please do so by going to Configuration -> Space Edit. Follow the info link for more information."
-				);
+				if (model.Config.settings.swIdMandatory === "true") {
+					sap.m.MessageBox.warning(
+						"You did not provide the " + model.Config.getSwIdLabel() +
+						" Please do so by going to Configuration -> Space Edit. Follow the info link for more information."
+					)
+				}
 			}
 
 			body = body + '}'


### PR DESCRIPTION
<!-- Describe your contribution -->
- adds restbackend.properties so that we don't display blank info on the frontend
- disables warning for SWID when SWID is not required
- fixes all HAProxy health checks
- creates exporter folders #158 
- removes haproxy.cfg duplication (both COPYied and shared, now only shared) #158 
- shares `.env` file to only selected containers
- removes `spring.datasource.username` and `spring.datasource.password` from `.env` file, now the compose uses directly `POSTGRES_USER` and `POSTGRES_PASSWORD` for restbackend
<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [x] Tested locally
- [x] Documentation