### PR TITLE
Slicing instrumentor and trace collection for Java packages and classes

### DIFF
--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/Callgraph.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/Callgraph.java
@@ -1,7 +1,6 @@
 package com.sap.psr.vulas.cg;
 
 import java.io.File;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -25,7 +24,6 @@ import com.sap.psr.vulas.FileAnalysisException;
 import com.sap.psr.vulas.java.JarAnalyzer;
 import com.sap.psr.vulas.java.JavaClassId;
 import com.sap.psr.vulas.java.JavaId;
-import com.sap.psr.vulas.java.JavaPackageId;
 import com.sap.psr.vulas.monitor.ClassPoolUpdater;
 import com.sap.psr.vulas.monitor.ClassVisitor;
 
@@ -73,14 +71,6 @@ public class Callgraph {
 	 * most of them share the JAR with others methods
 	 */
 	private final HashMap<URL, JarAnalyzer> jarAnalyzersCache = new HashMap<URL, JarAnalyzer>();
-
-	/**
-	 * Maps all callgraph integerIDs {@link Callgraph#nodeId} to their String containing the 
-	 * JAR url
-	 * 
-	 * @see Callgraph#nodeId
-	 */
-	//private final HashMap<Integer, String> jarMap = new HashMap<Integer, String>();
 
 	/**
 	 * Cache of JAR URLs for given construct Ids.
@@ -176,48 +166,6 @@ public class Callgraph {
 		}
 	}
 
-
-	/*public Callgraph (Graph<ConstructId> _g) {
-		if( _g!=null ) {
-			Iterator<ConstructId> iter = _g.iterator();
-			ConstructId src_node = null, tgt_node = null;
-			Iterator<ConstructId> succNodes = null;
-			Integer src_id = null, tgt_id = null, count = -1;
-
-			// Populate the map of constructs and integers
-			while (iter.hasNext()) {
-				this.nodeCount++;
-				src_node = iter.next();
-				src_id = this.nodeMap.get(src_node);
-				if(src_id == null) {
-					src_id = ++count;
-					this.nodeMap.put(src_node, src_id);
-					this.nodeInfoMap.put(src_id, this.createNodeMetaInformation(src_node, src_id));
-					this.nodeId.add(src_node);
-					this.idgraph.addNode(src_id);
-				}
-				//targets
-				succNodes = _g.getSuccNodes(src_node);
-				while(succNodes.hasNext()){
-					this.edgeCount++;
-					tgt_node = succNodes.next();
-					tgt_id = this.nodeMap.get(tgt_node);
-					if(tgt_id == null) {
-						tgt_id = ++count;
-						this.nodeMap.put(tgt_node, tgt_id);
-						this.nodeInfoMap.put(tgt_id, this.createNodeMetaInformation(tgt_node, tgt_id));
-						this.nodeId.add(tgt_node);
-						this.idgraph.addNode(tgt_id);
-					}
-					//add edges
-					this.idgraph.addEdge(src_id, tgt_id);
-				}
-			}
-			Callgraph.log.info("Built Graph<Integer> of " + this.idgraph.getNumberOfNodes() + " nodes");
-		}
-	}*/
-
-
 	/** 
 	 * Given a {@link ConstructId} and its ID (look {@link Callgraph#nodeId}) return
 	 * the NodeMetaInformation object that represent this node.
@@ -264,28 +212,10 @@ public class Callgraph {
 	public int getEdgeCount() { return this.edgeCount; }
 
 	/**
-	 * Returns the {@link JavaPackageId} of a given {@link ConstructId}.
-	 * 
-	 * @param _cid
-	 * @return
-	 */
-	public static JavaPackageId getPackageId (ConstructId _cid) {
-		JavaPackageId pid = null;
-		if(_cid instanceof com.sap.psr.vulas.java.JavaPackageId)
-			pid = (JavaPackageId) _cid;
-		else if(_cid instanceof com.sap.psr.vulas.java.JavaId)
-			pid = ((JavaId)_cid).getJavaPackageId();
-		else
-			Callgraph.log.error("Cannot find the package id for construct [" + _cid.getQualifiedName() + "]");
-		return pid;
-	}
-
-	/**
 	 * Given a target (changes), compute the shortest distance from all nodes to this target
 	 * @param _tgt
 	 * @return
 	 */
-
 	public Map<com.sap.psr.vulas.shared.json.model.ConstructId, Integer> getDist (com.sap.psr.vulas.shared.json.model.ConstructId _tgt) {
 
 		// Initialize the distances map, whereby the distance from source to source is 0,

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphReachableSearch.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/CallgraphReachableSearch.java
@@ -162,50 +162,6 @@ public class CallgraphReachableSearch implements Runnable {
 							log.error(e.getClass().getSimpleName() + " occured when looping callgraph node " + current_node_metainf + ": " + e.getMessage());
 						}
 					}
-
-					/*while (wala_graph_iterator.hasNext()) {
-						try {
-							// Current node and its meta information
-							current_node = wala_graph_iterator.next();
-
-							// HP, 29.11.2017: Poor implementation, use Spliterator instead
-							if(min <= current_node && current_node < max) {
-								current_node_metainf = this.graph.getInformationForId(current_node);
-								current_node_qname = current_node_metainf.getConstructId().getQualifiedName();
-
-								// Current node is part of library --> reachable constructs
-								if(MethodNameFilter.getInstance().isLibraryMethod(this.appConstructs, current_node_qname)) {
-									if(!MethodNameFilter.getInstance().isBlackListed(current_node_qname))
-										this.addReachableNode(current_node_metainf);
-								}
-								// Current node is part of app --> touch points
-								else {
-									// Collection enabled?
-									if(this.findTouchPoints) {
-										// Loop all successors of the current node
-										successor_nodes_iterator = wala_graph.getSuccNodes(current_node);
-										while(successor_nodes_iterator.hasNext()){
-
-											// Successor node of the current node
-											successor_node = successor_nodes_iterator.next();
-											successor_node_metainf = this.graph.getInformationForId(successor_node);
-
-											final String succ_node_qname = successor_node_metainf.getConstructId().getQualifiedName();
-											if(MethodNameFilter.getInstance().isLibraryMethod(this.appConstructs, succ_node_qname) && !MethodNameFilter.getInstance().isBlackListed(succ_node_qname)){
-												//current_node_metainf.addToList(successor_node_metainf);
-												this.addTouchPoint(current_node_metainf, successor_node_metainf);
-											}
-										}
-									}
-								}								
-								sw.progress();
-							}
-
-							//TODO Davide: Also collect touchpoints from Library to Application (L2A)
-						} catch(Exception e) {
-							log.error(e.getClass().getSimpleName() + " occured when looping callgraph node " + current_node_metainf + ": " + e.getMessage());
-						}
-					}*/
 					sw.stop();
 				}
 			}

--- a/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/NodeMetaInformation.java
+++ b/lang-java-reach/src/main/java/com/sap/psr/vulas/cg/NodeMetaInformation.java
@@ -17,7 +17,6 @@ import com.sap.psr.vulas.shared.json.JacksonUtil;
 import com.sap.psr.vulas.shared.json.model.ConstructId;
 
 /**
- * 
  * This class represent the MetaInformation that a node in the {@link CallGraph} can carry with himself
  */
 public class NodeMetaInformation {

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JavaId.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JavaId.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -203,14 +204,27 @@ public abstract class JavaId extends ConstructId {
 	 */
 	public static com.sap.psr.vulas.ConstructId toCoreType(com.sap.psr.vulas.shared.json.model.ConstructId _cid) {
 		switch(_cid.getType()) {
-		case METH: return JavaId.parseMethodQName(_cid.getQname());
-		case CONS: return JavaId.parseConstructorQName(_cid.getQname());
-		case PACK: return new JavaPackageId(_cid.getQname());
-		case INIT: return JavaId.parseClassInitQName(_cid.getQname());
-		case ENUM: return JavaId.parseEnumQName(_cid.getQname());
-		case CLAS: return JavaId.parseClassQName(_cid.getQname());
-		default: throw new IllegalArgumentException("Unknown type [" + _cid.getType() + "]");
+			case METH: return JavaId.parseMethodQName(_cid.getQname());
+			case CONS: return JavaId.parseConstructorQName(_cid.getQname());
+			case PACK: return new JavaPackageId(_cid.getQname());
+			case INIT: return JavaId.parseClassInitQName(_cid.getQname());
+			case ENUM: return JavaId.parseEnumQName(_cid.getQname());
+			case CLAS: return JavaId.parseClassQName(_cid.getQname());
+			default: throw new IllegalArgumentException("Unknown type [" + _cid.getType() + "]");
 		}
+	}
+	
+	/**
+	 * Transforms a collection of objects with a given shared type (defined in vulas-share) into
+	 * a {@link HashSet} of objects having the corresponding core type (defined in vulas-core).
+	 * @param _cid
+	 * @return
+	 */
+	public static Set<com.sap.psr.vulas.ConstructId> toCoreType(Collection<com.sap.psr.vulas.shared.json.model.ConstructId> _cids) {
+		final Set<com.sap.psr.vulas.ConstructId> cids = new HashSet<com.sap.psr.vulas.ConstructId>();
+		for(com.sap.psr.vulas.shared.json.model.ConstructId cid: _cids)
+			cids.add(JavaId.toCoreType(cid));
+		return cids;
 	}
 
 	/**

--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JavaId.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JavaId.java
@@ -605,16 +605,37 @@ public abstract class JavaId extends ConstructId {
 		}
 		
 		// Transform "jar:file:/.../foo.jar!bar.class" into "file:/.../foo.jar"
-		if(url!=null && url.toString().startsWith("jar:")) {
-			final String url_string = url.toString().substring(4, url.toString().indexOf(".jar")+4);
+		if(url!=null && url.toString().startsWith("jar:")) {			
 			try {
-				return new URL(url_string);
+				return JavaId.getJarUrl(url);
 			} catch (MalformedURLException e) {
-				JavaId.log.error("Cannot create URL from [" + url_string + "]: " + e.getMessage());
+				JavaId.log.error("Cannot create URL from [" + url.toString() + "]: " + e.getMessage());
 			}
 		}
 		
 		// Return null
+		return null;
+	}
+	
+	/**
+	 * Transform URLs like "jar:file:/.../foo.jar!bar.class" into "file:/.../foo.jar".
+	 * @param _url
+	 */
+	public final static URL getJarUrl(URL _url) throws MalformedURLException {
+		if(_url!=null && _url.toString().startsWith("jar:")) {
+
+			// The following creates problem in cases such as org.eclipse.equinox.p2.jarprocessor_1.0.300.v20130327-2119.jar, where ".jar" occurs two times
+			//final String url_string = url.toString().substring(4, url.toString().indexOf(".jar")+4);
+			
+			String url_string = _url.toString();
+			final int last_excl = url_string.lastIndexOf("!");
+			url_string = url_string.substring(4, url_string.lastIndexOf(".jar", (last_excl==-1 ? url_string.length() : last_excl)) + 4);
+			try {
+				return new URL(url_string);
+			} catch (MalformedURLException e) {
+				throw new MalformedURLException("Cannot create URL from [" + _url.toString() + "]: " + e.getMessage());
+			}
+		}
 		return null;
 	}
 	

--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/slice/SliceInstrumentor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/slice/SliceInstrumentor.java
@@ -1,0 +1,107 @@
+package com.sap.psr.vulas.monitor.slice;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.sap.psr.vulas.ConstructId;
+import com.sap.psr.vulas.backend.BackendConnectionException;
+import com.sap.psr.vulas.backend.BackendConnector;
+import com.sap.psr.vulas.core.util.CoreConfiguration;
+import com.sap.psr.vulas.goals.AbstractGoal;
+import com.sap.psr.vulas.java.JavaId;
+import com.sap.psr.vulas.monitor.AbstractInstrumentor;
+import com.sap.psr.vulas.monitor.ClassVisitor;
+import com.sap.psr.vulas.shared.json.model.Dependency;
+
+import javassist.CannotCompileException;
+import javassist.CtBehavior;
+
+/**
+ * Adds a configurable guard to all methods that have not been traced or found reachable.
+ */
+public class SliceInstrumentor extends AbstractInstrumentor {
+
+	// ====================================== STATIC MEMBERS
+
+	private static final Log log = LogFactory.getLog(SliceInstrumentor.class);
+
+	// ====================================== INSTANCE MEMBERS
+
+	/**
+	 * Constructs that have been traced.
+	 */
+	private Set<ConstructId> tracedConstructs = null;
+
+	/**
+	 * Constructs that have been found reachable.
+	 */
+	private Set<Dependency> dependencies = null;
+	
+	public SliceInstrumentor() {
+		try {
+			this.tracedConstructs = JavaId.toCoreType(BackendConnector.getInstance().getAppTraces(CoreConfiguration.buildGoalContextFromConfiguration(this.vulasConfiguration), CoreConfiguration.getAppContext(this.vulasConfiguration)));
+			this.dependencies = BackendConnector.getInstance().getAppDependencies(CoreConfiguration.buildGoalContextFromConfiguration(this.vulasConfiguration), CoreConfiguration.getAppContext(this.vulasConfiguration));
+		} catch (ConfigurationException e) {
+			SliceInstrumentor.log.error("Error during instantiation: " + e.getMessage());
+			throw new IllegalStateException("Error during instantiation: " + e.getMessage(), e);
+		} catch (IllegalStateException e) {
+			SliceInstrumentor.log.error("Error during instantiation: " + e.getMessage());
+			throw new IllegalStateException("Error during instantiation: " + e.getMessage(), e);
+		} catch (BackendConnectionException e) {
+			SliceInstrumentor.log.error("Error during instantiation: " + e.getMessage());
+			throw new IllegalStateException("Error during instantiation: " + e.getMessage(), e);
+		}
+	}
+	
+	/**
+	 * Accepts every construct that has been traced or found reachable.
+	 */
+	@Override
+	public boolean acceptToInstrument(JavaId _jid, CtBehavior _behavior, ClassVisitor _cv) {
+		return !this.tracedConstructs.contains(_jid) && !this.isReachable(_jid);
+	}
+	
+	/**
+	 * Returns true if the given {@link JavaId} is among the reachable constructs of any of the application {@link Dependency}s, false otherwise.
+	 */
+	private boolean isReachable(JavaId _jid) {
+		boolean is_reachable = false;
+		for(Dependency d: this.dependencies) {
+			if(d.getReachableConstructIds().contains(_jid)) {
+				is_reachable = true;
+				break;
+			}
+		}
+		return is_reachable;
+	}
+
+	public void instrument(StringBuffer _code, JavaId _jid, CtBehavior _behavior, ClassVisitor _cv) throws CannotCompileException {
+		_code.append("final boolean is_open = Boolean.parseBoolean(System.getProperty(\"").append(CoreConfiguration.INSTR_GUARD_OPEN).append("\"));");
+		_code.append("System.err.println(\"Execution of " + _jid.toString() + "\" + (is_open ? \"allowed\" : \"prevented\") + \" by Vulas guarding condition\");");
+		_code.append("if(!is_open) throw new IllegalStateException(\"Execution of " + _jid.toString() + "\" + prevented by Vulas guarding condition\");");
+	}
+	
+	/**
+	 * Implementation does not do anything.
+	 */
+	@Override
+	public void upladInformation(AbstractGoal _exe, int _batch_size) { ; }
+
+	/**
+	 * Implementation does not do anything.
+	 */
+	@Override
+	public void awaitUpload() { ; }
+
+	@Override
+	public Map<String,Long> getStatistics() {
+		final Map<String, Long> stats = new HashMap<String, Long>();
+		//TODO: Add number of instrumented methods
+		return stats;
+	}
+}

--- a/lang-java/src/test/java/com/sap/psr/vulas/java/JavaIdTest.java
+++ b/lang-java/src/test/java/com/sap/psr/vulas/java/JavaIdTest.java
@@ -3,6 +3,7 @@ package com.sap.psr.vulas.java;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -231,4 +232,27 @@ public class JavaIdTest {
 	  assertEquals(hashSet, retval);
 	}
 
+	@Test
+	public void testGetJarUrl() {
+		try {
+			URL u = Class.forName("org.junit.Assert").getResource('/' + "org.junit.Assert".replace('.', '/') + ".class");//new URL("jar:file:/test/foo.jar!bar.class");
+			URL uj = JavaId.getJarUrl(u);
+			assertTrue(uj.toString().matches("^file:/.*/\\.m2/repository/junit/junit/.*/junit-.*\\.jar$"));
+			
+			u = Class.forName("java.util.jar.JarFile").getResource('/' + "java.util.jar.JarFile".replace('.', '/') + ".class");//new URL("jar:file:/test/foo.jar!bar.class");
+			uj = JavaId.getJarUrl(u);
+			assertTrue(uj!=null);
+						
+			u = new URL("jar", "", "file:/org.eclipse.equinox.p2.jarprocessor_1.0.300.v20130327-2119.jar");
+			uj = JavaId.getJarUrl(u);
+			assertEquals("file:/org.eclipse.equinox.p2.jarprocessor_1.0.300.v20130327-2119.jar", uj.toString());
+			
+			u = new URL("jar", "", "file:/org.eclipse.equinox.p2.jarprocessor_1.0.300.v20130327-2119.jar!bar.class");
+			uj = JavaId.getJarUrl(u);
+			assertEquals("file:/org.eclipse.equinox.p2.jarprocessor_1.0.300.v20130327-2119.jar", uj.toString());
+		} catch (Exception e) {
+			e.printStackTrace();
+			assertTrue(false);
+		}		
+	}
 }

--- a/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
+++ b/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
@@ -107,6 +107,8 @@ public class CoreConfiguration {
 
 	public final static String INSTR_BLACKLIST_CLASSLOADER    = "vulas.core.instr.blacklist.classloader";
 	public final static String INSTR_BLACKLIST_CLASSLOADER_ACC_CHILD = "vulas.core.instr.whitelist.classloader.acceptChilds";
+	
+	public final static String INSTR_GUARD_OPEN = "vulas.core.instr.guard.open";
 
 	public final static String MONI_PERIODIC_UPL_ENABLED    = "vulas.core.monitor.periodicUpload.enabled";
 	public final static String MONI_PERIODIC_UPL_INTERVAL   = "vulas.core.monitor.periodicUpload.interval";

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/ApplicationController.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/ApplicationController.java
@@ -9,7 +9,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -1662,6 +1661,32 @@ public class ApplicationController {
 
 		// Save and return
 		return new ResponseEntity<List<Trace>>(this.traceRepository.findByApp(app), HttpStatus.OK);
+	}
+	
+	/**
+	 * Returns a {@link Collection} of all application {@link Dependency}s including their reachable {@link ConstructId}s. 
+	 * @param 
+	 * @return 409 {@link HttpStatus#CONFLICT} if bug with given bug ID already exists, 201 {@link HttpStatus#CREATED} if the bug was successfully created
+	 */
+	@RequestMapping(value = "/{mvnGroup:.+}/{artifact:.+}/{version:.+}/reachableConstructIds", method = RequestMethod.GET, produces = {"application/json;charset=UTF-8"})
+	@JsonView(Views.DepDetails.class)
+	public ResponseEntity<Collection<Dependency>> getReachableContructIds(@PathVariable String mvnGroup, @PathVariable String artifact, @PathVariable String version,
+			@ApiIgnore @RequestHeader(value=Constants.HTTP_SPACE_HEADER, required=false) String space) {
+
+		Space s = null;
+		try {
+			s = this.spaceRepository.getSpace(space);
+		} catch (Exception e){
+			log.error("Error retrieving space: " + e);
+			return new ResponseEntity<Collection<Dependency>>(HttpStatus.NOT_FOUND);
+		}
+		// Ensure that app exists
+		Application app = null;
+		try { app = ApplicationRepository.FILTER.findOne(this.appRepository.findByGAV(mvnGroup,artifact,version,s)); }
+		catch (EntityNotFoundException e) { return new ResponseEntity<Collection<Dependency>>(HttpStatus.NOT_FOUND); }
+		
+		// Save and return
+		return new ResponseEntity<Collection<Dependency>>(app.getDependencies(), HttpStatus.OK);
 	}
 
 	/**

--- a/shared/src/main/java/com/sap/psr/vulas/shared/connectivity/PathBuilder.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/connectivity/PathBuilder.java
@@ -82,6 +82,12 @@ public class PathBuilder {
 		b.append(app(_app)).append("/traces");
 		return b.toString();
 	}
+	
+	public static final String appReachableConstructIds(@NotNull Application _app) {
+		final StringBuilder b = new StringBuilder();
+		b.append(app(_app)).append("/reachableConstructIds");
+		return b.toString();
+	}
 
 	public static final String appBugs(@NotNull Application _app) {
 		final StringBuilder b = new StringBuilder();


### PR DESCRIPTION
Improvements:
  - Traces will not be collected only for executable Java constructs (methods, constructors, static initializers), but also for Java packages and classes.
  - A new instrumentor injects code into each and every executable construct which has not been traced before. The injected code looks as follows, it is meant to write an error message and can be configured to throw an `IllegalStateException`:

```
    try {
      boolean bool = Boolean.parseBoolean(System.getProperty("vulas.core.instr.guard.open"));
      System.err.println("Execution of guarded JAVA METH [org.apache.struts.action.ActionFormBeans.getFast()]" + (bool ? "allowed" : "prevented") + " by Vulas guarding condition");
      if (!bool) {
        throw new IllegalStateException("Execution of guarded JAVA METH [org.apache.struts.action.ActionFormBeans.getFast()] prevented by Vulas guarding condition");
      }
    }
    catch (IllegalStateException localIllegalStateException) {
      throw localIllegalStateException;
    }
    catch (Throwable localThrowable) {
      System.err.println(localThrowable.getClass().getName() + " occurred during execution of instrumentation code in JAVA METH [org.apache.struts.action.ActionFormBeans.getFast()]: " + localThrowable.getMessage());
    }
```

Bug fix:
  - In case the JAR file name contains the string `.jar` multiple times (thus, not only as file extension), the method `JavaId.getJarUrl` did not work properly
