### PR TITLE
Exclude dependencies not available in Central

### DIFF
--- a/lang-java-reach-soot/pom.xml
+++ b/lang-java-reach-soot/pom.xml
@@ -30,6 +30,18 @@
 			<artifactId>soot-infoflow</artifactId>
 			<version>2.7.1.1</version>
 			<scope>compile</scope>
+			<!-- Defined in its dependency on soot:3.2.0, which is any how irrelevant 
+				due to the above dep on soot:3.2.0 -->
+			<exclusions>
+				<exclusion>
+					<groupId>pxb.android</groupId>
+					<artifactId>axml</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>heros</groupId>
+					<artifactId>heros</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Fix Soot's dependency on Guava 18.0 (CVE-2018-10237) -->
@@ -38,6 +50,5 @@
 			<artifactId>guava</artifactId>
 			<version>27.1-jre</version>
 		</dependency>
-		
 	</dependencies>
 </project>


### PR DESCRIPTION
Infoflow depends on `soot:3.2.0`, which has a few dependencies that are not available in Central. Anyhow, those will be discarded due to another dependency on `soot:3.3.0`. As such, in order to prevent problems at the time of the Maven dependency resultion, they are explicitely excluded.

#### `TODO`s

- [x] Tests
- [ ] Documentation