### PR TITLE
Hide superfluous elements wrongly displayed

### DIFF
--- a/docs/public/content/css/override.css
+++ b/docs/public/content/css/override.css
@@ -286,3 +286,8 @@ a>code {
     font-weight: 600;
     font-size: 20px;
 }
+
+/* Github stars and forks - start */
+ul.md-source__facts:not(:nth-of-type(1)) {
+    display: none;
+}


### PR DESCRIPTION
squidfunk/mkdocs-material displays multiple times the stars and the forks of the repository if a user reloads the page very fast. This fix hides those copies.

<!-- Describe your contribution -->

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [x] Tested locally
- [ ] Documentation