### PR TITLE
refresh of app 'lastChanged' flag when traces are saved

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/TracesRepositoryImpl.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/TracesRepositoryImpl.java
@@ -130,6 +130,10 @@ public class TracesRepositoryImpl implements TracesRepositoryCustom {
 				throw new PersistenceException("Error while saving trace " + provided_trace + ": " + e.getMessage());
 			}
 		}
+		//After all traces have been saved,
+		//update the lastScan timestamp of the application (we already have a managed application here)
+		appRepository.refreshLastScanbyApp(_app);
+		
 		sw.stop();
 		return traces;
 	}


### PR DESCRIPTION
Update application 'lastChanged' flag whenever traces are uploaded. Required to get refreshed data in the frontend when instrumentation is done outside of JUnit tests.

Drawback: When traces are uploaded within JUnit tests by running mvn -Dvulas vulas:prepare-vulas-agent test vulas:upload, 'lastChanged' is updated 3 times: when saving the test and upload goal and while saving the traces. Still, it only impacts 1 application so the overhead should be acceptable.

The current implementation works if it never happens that we save paths without saving traces.

#### `TODO`s

- [x] Tests
- [ ] Documentation