### PR TITLE
Allow the overriding of the version of Maven modules for report goal

### DIFF
--- a/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
+++ b/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
@@ -72,6 +72,7 @@ public class CoreConfiguration {
 	public final static String REP_EXCL_UNASS    = "vulas.report.exceptionExcludeUnassessed";
 	public final static String REP_EXCL_BUGS     = "vulas.report.exceptionExcludeBugs";
 	public final static String REP_DIR           = "vulas.report.reportDir";
+	public final static String REP_OVERRIDE_VER  = "vulas.report.overridePomVersion";
 
 	public final static String SEQ_DEFAULT       = "vulas.core.sequence.defaultGoals";
 

--- a/lang/src/main/java/com/sap/psr/vulas/report/Report.java
+++ b/lang/src/main/java/com/sap/psr/vulas/report/Report.java
@@ -108,10 +108,15 @@ public class Report {
 	public Report(GoalContext _ctx, Application _app, Set<Application> _modules) {
 		this.goalContext = _ctx;
 		this.app = _app;
-		if(_modules==null) this.modules = new HashSet<Application>();
-		else this.modules = _modules;
-		this.modules.add(app);			
-		Report.log.info("Report to be done for " + _app + ", [" + this.modules.size() + "] modules in total: " + this.modules);
+
+		if(_modules==null) {
+			this.modules = new HashSet<Application>();
+			this.modules.add(this.app);
+		}
+		else
+			this.modules = _modules;
+				
+		Report.log.info("Report to be done for " + this.app + ", [" + this.modules.size() + "] modules in total: " + this.modules);
 	}
 
 	public String getExceptionThreshold() { return exceptionThreshold; }

--- a/lang/src/main/resources/vulas-core.properties
+++ b/lang/src/main/resources/vulas-core.properties
@@ -168,7 +168,12 @@ vulas.report.exceptionExcludeBugs =
 #   MVN: ${project.build.directory}/vulas/report
 vulas.report.reportDir =
 
-
+# If true, the report will be created for modules with a version corresponding to vulas.core.appContext.version.
+# If false, the module version will be taken from the pom.xml.
+#
+# Default: false
+# Note: This setting is only relevant in the context of Maven
+#vulas.report.overridePomVersion = false
 
 ########## vulas:sequence
 

--- a/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/MvnPluginReport.java
+++ b/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/MvnPluginReport.java
@@ -8,13 +8,15 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 
+import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.goals.ReportException;
 import com.sap.psr.vulas.goals.ReportGoal;
 import com.sap.psr.vulas.shared.json.model.Application;
+import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
 @Mojo( name = "report", defaultPhase = LifecyclePhase.VERIFY, requiresOnline = true )
 public class MvnPluginReport extends AbstractVulasMojo {
-
+	
 	@Override
 	protected void createGoal() {
 		this.goal = new ReportGoal();
@@ -37,13 +39,38 @@ public class MvnPluginReport extends AbstractVulasMojo {
 	}
 
 	/**
-	 * Recursively loops over the subprojects of the given project in order to build
-	 * a complete set of {@link Application} modules.
+	 * Builds the set of {@link Application}s to be considered in the result report.
+	 * 
+	 * If the given {@link MavenProject} has the packaging type 'POM', applications
+	 * corresponding to all its sub-modules will be added to this set.
+	 * 
+	 * Depending on the configuration option {@link CoreConfiguration#REP_OVERRIDE_VER},
+	 * the application version is either taken from the POM or from configuration
+	 * setting {@link CoreConfiguration#APP_CTX_VERSI}.
+	 * 
 	 * @param _prj
 	 * @param _ids
 	 */
 	private void collectApplicationModules(MavenProject _prj, Set<Application> _ids) {
-		_ids.add(new Application(_prj.getGroupId(), _prj.getArtifactId(), _prj.getVersion()));
+
+		// The version as specified in the POM of the given project		
+		final String pom_version = _prj.getVersion();
+		
+		// The version specified with configuration option {@link CoreConfiguration#APP_CTX_VERSI}
+		final String app_ctx_version = this.goal.getGoalContext().getApplication().getVersion();
+		
+		// The application module to be added
+		final Application app = new Application(_prj.getGroupId(), _prj.getArtifactId(), pom_version);
+		
+		// Override version found in the respective pom.xml with the version of the application context
+		// This becomes necessary if module scan results are NOT uploaded with the version found in the POM,
+		// but with one specified in other ways, e.g., per -Dvulas.core.appContext.version
+		if(this.vulasConfiguration.getConfiguration().getBoolean(CoreConfiguration.REP_OVERRIDE_VER, false) && !pom_version.equals(app_ctx_version)) {
+			app.setVersion(app_ctx_version);
+			this.getLog().warn("Report will include application version " + app + " rather than version [" + pom_version + "] specified in its POM");
+		}
+		
+		_ids.add(app);
 		if(_prj.getPackaging().equalsIgnoreCase("pom")) {
 			for(MavenProject module: _prj.getCollectedProjects()) {
 				this.collectApplicationModules(module, _ids);

--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/VulasConfiguration.java
@@ -105,7 +105,7 @@ public class VulasConfiguration {
 	private Configuration writableConfiguration = new MapConfiguration(new HashMap<String,Object>());
 	
 	// Add the initial ones right away
-	public VulasConfiguration( ){
+	public VulasConfiguration() {
 		this.appendInitialConfigurations();
 	}
 


### PR DESCRIPTION
Bug: If the version of the application context is different from the version specified in the `pom.xml`, e.g., because the user specified `vulas.core.appContext.version` explicitily in the Maven command line, the report goal tries to read findings from the backend using the wrong version.

Solution: If the new configuration setting `vulas.report.overridePomVersion` is set to true, the version provided in the `pom.xml` will be overriden with the version of the application context.

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [ ] Documentation