### PR TITLE
Frontend performance

### DIFF
--- a/frontend-apps/src/main/webapp/i18n/messageBundle_en_US.properties
+++ b/frontend-apps/src/main/webapp/i18n/messageBundle_en_US.properties
@@ -1,0 +1,47 @@
+masterTitle=OSS Vulnerability Assessment
+MasterViewTitle=Applications
+masterBusyText=Loading Data...
+
+MasterTableAppColumn=Application
+MasterTableGroupIdColumn=GroupId
+MasterTableArtifactIdColumn=ArtifactId
+MasterTableVersionColumn=Version
+
+masterSearchPlaceholder=Group, artifact, version...
+masterSearchTooltip=Search application by Maven artifact coordinates, i.e., GroupId, ArtifactId or Version
+masterSearchRefreshTooltip=Redo search
+masterAppReloadTooltip=Reload applications
+
+Archives=Dependencies
+patchAnalysis=Vulnerabilities
+mavenVerified=Maven-verified archive
+testCoverageTitle=Testcoverage for 
+archivesTC=Archives
+
+# Dependencies
+wellknownDigest=Well-known Digest
+digestTimestamp=Release Date
+declaredDependency=Declared Dependency
+
+GoalExecutions=History
+mitigation=Mitigation
+
+# Test Coverage / Statistics
+testCoverage=Statistics
+
+# Ratio table
+ratioConstructType=Construct Type
+ratioConstructApp=Application
+ratioConstructDeps=Total (app + dependencies)
+ratioConstructRatio=Percentage (app/total)
+# Metric names coming from the backend service
+class_ratio=Classes
+package_ratio=Packages
+executable_ratio=Executable constructs (methods, constructors, static initializers)
+
+# Test coverage table
+packages=Application Package
+constructors=Constructors (traced/total)
+methods=Methods (traced/total)
+static_inits=Static Initializers (traced/total)
+coverage=Test Coverage

--- a/frontend-apps/src/main/webapp/index.html
+++ b/frontend-apps/src/main/webapp/index.html
@@ -7,41 +7,58 @@
 
 	<title>Vulas Application Analysis Frontend</title>
 
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/core/themes/sap_belize/library.css" as="style">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/m/themes/sap_belize/library.css" as="style">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/layout/themes/sap_belize/library.css" as="style">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/unified/themes/sap_belize/library.css" as="style">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/commons/themes/sap_belize/library.css" as="style">
+	<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js" as="script">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap-ui-core.js" as="script">
+	<link rel="preload" href="https://cdn.jsdelivr.net/npm/d3@3.5.17/d3.min.js" as="script">
+	<link rel="preload" href="https://ssl.gstatic.com/trends_nrtr/1754_RC01/embed_loader.js" as="script">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/core/library-preload.js" as="script">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/m/library-preload.js" as="script">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/unified/library-preload.js" as="script">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/layout/library-preload.js" as="script">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/commons/library-preload.js" as="script">
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/core/themes/sap_belize/fonts/72-Regular.woff2" as="font" crossorigin>
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/core/themes/base/fonts/SAP-icons.woff2" as="font" crossorigin>
+	<link rel="preload" href="https://openui5.hana.ondemand.com/resources/sap/ui/core/themes/sap_belize/fonts/72-Bold.woff2" as="font" crossorigin>
+
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<link href="img/icon.png" rel="shortcut icon" type="image/x-icon" />
 
-	<script defer src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js" integrity="sha256-7/yoZS3548fXSRXqc/xYzjsmuW3sFKzuvOCHd06Pmps="
-	 crossorigin="anonymous"></script>
+	<script defer src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js"></script>
 	<script defer id="sap-ui-bootstrap" type="text/javascript" src="https://openui5.hana.ondemand.com/resources/sap-ui-core.js"
 	 data-sap-ui-theme="sap_belize" data-sap-ui-compatVersion="edge" data-sap-ui-libs='sap.m, sap.ui.layout, sap.ui.commons'
-	 data-sap-ui-xx-bindingSyntax="complex" data-sap-ui-resourceroots='{
+	 data-sap-ui-xx-bindingSyntax="complex" data-sap-ui-async="true" data-sap-ui-resourceroots='{
 		"vulasfrontend": "./",
 		"view" : "./view",
 		"model" : "./model",
 		"util" : "./util"
 	}'>
 	</script>
-	<script defer src="https://cdn.jsdelivr.net/npm/d3@3.5.17/d3.min.js" integrity="sha256-dsOXGNHAo/syFnazt+KTBsCQeRmlcW1XKL0bCK4Baec="
-	 crossorigin="anonymous"></script>
+	<script defer src="https://cdn.jsdelivr.net/npm/d3@3.5.17/d3.min.js"></script>
 
 	<!-- <script defer src="./helpers/basePriorityQueue.js"></script>
 	<script defer src="./helpers/pqueue.js"></script> -->
 	<script defer src="./helpers/transpiled/basePriorityQueueES5.js"></script>
 	<script defer src="./helpers/transpiled/pqueueES5.js"></script>
 
-	<script defer type="text/javascript" src="https://ssl.gstatic.com/trends_nrtr/1173_RC01/embed_loader.js"></script>
+	<script defer type="text/javascript" src="https://ssl.gstatic.com/trends_nrtr/1754_RC01/embed_loader.js"></script>
 	<script>
 		document.addEventListener('DOMContentLoaded', function () {
-			new sap.m.Shell("Shell", {
-				title: "VULAS",
-				logo: "img/icon.png",
-				showLogout: false,
-				app: new sap.ui.core.ComponentContainer({
-					name: 'vulasfrontend'
-				}),
-				appWidthLimited: false
-			}).placeAt('content')
-			
+			sap.ui.getCore().attachInit(function(){
+				new sap.m.Shell("Shell", {
+					title: "VULAS",
+					logo: "img/icon.png",
+					showLogout: false,
+					app: new sap.ui.core.ComponentContainer({
+						name: 'vulasfrontend'
+					}),
+					appWidthLimited: false
+				}).placeAt('content')
+			});
 		})
 	</script>
 </head>


### PR DESCRIPTION
<!-- Describe your contribution -->
Improve frontend-apps performances (initial loading time) by:

- asynchronously loading UI5 core library
- [preloading](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content) scripts/stylesheets/fonts

I couldn't preload the `.properties` and `.json` files since those are fetched by UI5 with custom headers and preloading doesn't support custom headers.

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [x] Tested locally
- [ ] Documentation