### PR TITLE
Exclude tests.py from query for vulndeps

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepository.java
@@ -178,7 +178,7 @@ public interface ApplicationRepository extends CrudRepository<Application, Long>
 			+ "   AND lc = cc.constructId"		
 			+ "   AND (NOT lc.type='PACK' "                        // Java + Python exception
 			+ "   OR NOT EXISTS (SELECT 1 FROM ConstructChange cc1 JOIN cc1.constructId c1 WHERE cc1.bug=cc.bug AND NOT c1.type='PACK' AND NOT c1.qname LIKE '%test%' AND NOT c1.qname LIKE '%Test%' and NOT cc1.constructChangeType='ADD') ) "      //select bug if all other cc of the same bug are PACK, ADD or Test changes
-			+ "   AND NOT (lc.type='MODU' AND lc.qname='setup')" // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs
+			+ "   AND NOT (lc.type='MODU' AND lc.qname='setup') AND NOT (lc.type='MODU' AND lc.qname='tests')" // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs. Similarly tests.py originates such a generic module that would bring up too many FPs
 			)
 	TreeSet<VulnerableDependency> findJPQLVulnerableDependenciesByGAV(@Param("mvnGroup") String group, @Param("artifact") String artifact, @Param("version") String version, @Param("space") Space space);
 


### PR DESCRIPTION
Modifications in "tests.py " originates a constructChange of type module for the qname "tests" which is too generic (i.e., it's not a unique FQN). Too avoid FPs we exclude it in the query (JOIN) for vulnerable dependencies

#### `TODO`s

- [x ] Tests
- [ ] Documentation