### PR TITLE
Load slicing black and whitelist from files

### DIFF
--- a/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassVisitor.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/monitor/ClassVisitor.java
@@ -367,10 +367,7 @@ public class ClassVisitor {
 	public byte[] getBytecode() { return this.bytes.clone(); }
 
 	public synchronized void addBooleanMember(String _field_name, boolean _value, boolean _final) throws CannotCompileException {
-		//final String src = "public static boolean " + _field_name + " = " + _value + ";";
-		//final CtField f = CtField.make(src, this.c);
-
-		CtField f = new CtField(CtClass.booleanType, _field_name, this.c);
+		final CtField f = new CtField(CtClass.booleanType, _field_name, this.c);
 		if(!_final)
 			f.setModifiers(Modifier.PUBLIC | Modifier.STATIC | Modifier.TRANSIENT);
 		else
@@ -401,10 +398,7 @@ public class ClassVisitor {
 	}
 
 	public synchronized void addIntMember(String _field_name, boolean _final) throws CannotCompileException {
-		//final String src = "public static boolean " + _field_name + " = " + _value + ";";
-		//final CtField f = CtField.make(src, this.c);
-
-		CtField f = new CtField(CtClass.intType, _field_name, this.c);
+		final CtField f = new CtField(CtClass.intType, _field_name, this.c);
 		if(!_final)
 			f.setModifiers(Modifier.PUBLIC | Modifier.STATIC | Modifier.TRANSIENT);
 		else

--- a/lang-java/src/main/resources/vulas-java.properties
+++ b/lang-java/src/main/resources/vulas-java.properties
@@ -31,6 +31,7 @@ vulas.core.jarAnalysis.poolSize = 4
 #   com.sap.psr.vulas.monitor.trace.SingleStackTraceInstrumentor: Collects at most "vulas.core.instr.maxStacktraces" call stack for every invoked vulnerable method
 #   com.sap.psr.vulas.monitor.trace.StackTraceInstrumentor:  Collects all call stacks for every invoked vulnerable method
 #   com.sap.psr.vulas.monitor.touch.TouchPointInstrumentor: Collects so-called touch points, i.e., calls from an app method to a library method
+#   com.sap.psr.vulas.monitor.slice.SliceInstrumentor: Modifies executable constructs such that, upon execution, a warning will be printed to stderr. The execution can be entirely prevented using a configuration setting
 #
 # Default: com.sap.psr.vulas.monitor.trace.SingleTraceInstrumentor
 #
@@ -100,6 +101,19 @@ vulas.core.instr.static.inclBackendUrl = true
 # Example: javax.persistence.Transient (to prevent issues with OR mappers)
 # Note: Make sure that the respective classes are present at runtime
 vulas.core.instr.fieldAnnotations = 
+
+# A whitelist of construct IDs to be instrumented by the SliceInstrumentor
+# Default: -
+#vulas.core.instr.slice.whitelist
+
+# A blacklist of construct IDs NOT to be instrumented by the SliceInstrumentor
+# Default: -
+#vulas.core.instr.slice.blacklist
+
+# Determines the default behavior of the guarding condition added by the SliceInstrumentor
+# Possible values: true, false
+# Default: true
+vulas.core.instr.slice.guardOpen = true
 
 # JARs for which no traces and no archive information will be uploaded (e.g., from Vulas itself)
 # Multiple entries are separated by comma, each entry is a regex

--- a/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
+++ b/lang/src/main/java/com/sap/psr/vulas/core/util/CoreConfiguration.java
@@ -111,7 +111,9 @@ public class CoreConfiguration {
 	public final static String INSTR_BLACKLIST_CLASSLOADER    = "vulas.core.instr.blacklist.classloader";
 	public final static String INSTR_BLACKLIST_CLASSLOADER_ACC_CHILD = "vulas.core.instr.whitelist.classloader.acceptChilds";
 	
-	public final static String INSTR_GUARD_OPEN = "vulas.core.instr.guard.open";
+	public final static String INSTR_SLICE_WHITELIST       = "vulas.core.instr.slice.whitelist";
+	public final static String INSTR_SLICE_BLACKLIST       = "vulas.core.instr.slice.blacklist";
+	public final static String INSTR_SLICE_GUARD_OPEN      = "vulas.core.instr.slice.guardOpen";
 
 	public final static String MONI_PERIODIC_UPL_ENABLED    = "vulas.core.monitor.periodicUpload.enabled";
 	public final static String MONI_PERIODIC_UPL_INTERVAL   = "vulas.core.monitor.periodicUpload.interval";


### PR DESCRIPTION
<!-- Describe your contribution -->
The whitelist (blacklist) of constructs (not) to be instrumented by the SliceInstrumentor can be read from a file (in addition to populating the blacklist with traced and reachable constructs determined during static and dynamic analysis).

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [ ] Documentation