### PR TITLE
exclude test.__init__ module from query for vulndeps

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/ApplicationRepository.java
@@ -178,7 +178,7 @@ public interface ApplicationRepository extends CrudRepository<Application, Long>
 			+ "   AND lc = cc.constructId"		
 			+ "   AND (NOT lc.type='PACK' "                        // Java + Python exception
 			+ "   OR NOT EXISTS (SELECT 1 FROM ConstructChange cc1 JOIN cc1.constructId c1 WHERE cc1.bug=cc.bug AND NOT c1.type='PACK' AND NOT c1.qname LIKE '%test%' AND NOT c1.qname LIKE '%Test%' and NOT cc1.constructChangeType='ADD') ) "      //select bug if all other cc of the same bug are PACK, ADD or Test changes
-			+ "   AND NOT (lc.type='MODU' AND (lc.qname='setup' OR lc.qname='tests')) " // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs. Similarly tests.py originates such a generic module that would bring up too many FPs
+			+ "   AND NOT (lc.type='MODU' AND (lc.qname='setup' OR lc.qname='tests' OR lc.qname='test.__init__')) " // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs. Similarly tests.py originates such a generic module that would bring up too many FPs
 			)
 	TreeSet<VulnerableDependency> findJPQLVulnerableDependenciesByGAV(@Param("mvnGroup") String group, @Param("artifact") String artifact, @Param("version") String version, @Param("space") Space space);
 
@@ -347,7 +347,7 @@ public interface ApplicationRepository extends CrudRepository<Application, Long>
 			+ "	  WHERE lc IN :listOfConstructs "		
 			+ "   AND (NOT lc.type='PACK' "                        // Java + Python exception
 			+ "   OR NOT EXISTS (SELECT 1 FROM ConstructChange cc1 JOIN cc1.constructId c1 WHERE c1 IN :listOfConstructs AND NOT c1.type='PACK' AND NOT c1.qname LIKE '%test%' AND NOT c1.qname LIKE '%Test%' and NOT cc1.constructChangeType='ADD') ) "     
-			+ "   AND NOT (lc.type='MODU' AND (lc.qname='setup' OR lc.qname='tests')) )" // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs. Similarly tests.py originates such a generic module that would bring up too many FPs
+			+ "   AND NOT (lc.type='MODU' AND (lc.qname='setup' OR lc.qname='tests' OR lc.qname='test.__init__')) )" // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs. Similarly tests.py originates such a generic module that would bring up too many FPs
 			)
 	List<Application> findAppsByCC(@Param("listOfConstructs") List<ConstructId> listOfConstructs);
 	

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/BugRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/BugRepository.java
@@ -48,7 +48,7 @@ public interface BugRepository extends CrudRepository<Bug, Long>, BugRepositoryC
 			+ "   AND lc = cc.constructId"		
 			+ "   AND (NOT lc.type='PACK' "                        // Java + Python exception
 			+ "   OR NOT EXISTS (SELECT 1 FROM ConstructChange cc1 JOIN cc1.constructId c1 WHERE cc1.bug=cc.bug AND NOT c1.type='PACK' AND NOT c1.qname LIKE '%test%' AND NOT c1.qname LIKE '%Test%' and NOT cc1.constructChangeType='ADD') ) "      //select bug if all other cc of the same bug are PACK, ADD or Test changes
-			+ "   AND NOT (lc.type='MODU' AND (lc.qname='setup' OR lc.qname='tests'))" // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs
+			+ "   AND NOT (lc.type='MODU' AND (lc.qname='setup' OR lc.qname='tests' OR lc.qname='test.__init__'))" // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs
 			)
 	List<Bug> findByLibrary(@Param("bundledDigest") Library bundledDigest);
 	

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepository.java
@@ -167,7 +167,7 @@ public interface LibraryRepository extends CrudRepository<Library, Long>, Librar
 			+ "   AND lc = cc.constructId"
 			+ "   AND (NOT lc.type='PACK' "                        // Java + Python exception
 			+ "   OR NOT EXISTS (SELECT 1 FROM ConstructChange cc1 JOIN cc1.constructId c1 WHERE cc1.bug=cc.bug AND NOT c1.type='PACK' AND NOT c1.qname LIKE '%test%' AND NOT c1.qname LIKE '%Test%' and NOT cc1.constructChangeType='ADD') ) "     
-			+ "   AND NOT (lc.type='MODU' AND (lc.qname='setup' OR lc.qname='tests'))" // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs. Similarly tests.py originates such a generic module that would bring up too many FPs
+			+ "   AND NOT (lc.type='MODU' AND (lc.qname='setup' OR lc.qname='tests' OR lc.qname='test.__init__'))" // Python-specific exception: setup.py is virtually everywhere, considering it would bring far too many FPs. Similarly tests.py originates such a generic module that would bring up too many FPs
 			)
 		List<Library> findJPQLVulnerableLibrariesByBug(@Param("bugId") String bugId);
 	


### PR DESCRIPTION
exclude test.__init__ python module from the query for vulndeps as it not "unique enough" to identify the vulnerable artifacts.


- [x] Tests
- [ ] Documentation