### PR TITLE
Exclude intra-project dependencies (that point to target/classes rather than an analyzable Java archive)

### DIFF
--- a/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
@@ -210,7 +210,6 @@ public class ArchiveAnalysisManager {
 				if(parent!=null)
 					ja.setParent(parent);
 
-				
 				ja.setRename(this.rename);
 				ja.setWorkDir(this.workDir);
 

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DependencyUtil.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DependencyUtil.java
@@ -108,13 +108,15 @@ public class DependencyUtil {
 						parent_set.add(d.getParent());
 				}
 				else {
-					log.warn("Dependency " + d + " occurs multiple times in the set, one on the same library already exists: " + existing_dep);
+					log.error("Dependency " + d + " occurs multiple times in the set, one on the same library already exists: " + existing_dep);
 					return false;
 				}
 			}
 			for(Dependency d: parent_set){
-				if(!main_set.contains(d))
+				if(!main_set.contains(d)) {
+					log.error("Dependency parent " + d + " is not declared as dependency itself");
 					return false;
+				}
 			}
 		}	
 		return true;


### PR DESCRIPTION
<!-- Describe your contribution -->

With release 3.1.0, intra-project dependencies (on other modules of a multi-module Maven project) appeared as parent dependencies in the JSON POSTed to `backend/apps`. Those intra-project dependencies do not necessarily exist in a Maven repository (depending on whether `mvn install` was run beforehand). The result of all this is that the consistency check in `DependencyUtil` failed, hence, the entire upload of applications failed.

The correction consists of suppressing intra-project dependencies as dependency parents.

<!-- Check if you tested/documented your contribution -->


#### `TODO`s

- [X] Tested locally with multi-module Maven test application
- [ ] Documentation