### PR TITLE
removed depth from UI

### DIFF
--- a/frontend-apps/src/main/webapp/view/Component.view.xml
+++ b/frontend-apps/src/main/webapp/view/Component.view.xml
@@ -245,15 +245,15 @@
 		 												formatter: 'model.Formatter.directTransitive'}"></TextView>
 										</template>
 									</Column>
-									<Column xmlns="sap.ui.table" width="10%">
-										<Label text="Depth" xmlns="sap.ui.commons" />
-										<template>
-											<TextView xmlns="sap.ui.commons"
-												text="{
-		 												path: 'parent',
-		 												formatter: 'model.Formatter.parentDepth'}"></TextView>
-										</template>
-									</Column>
+<!-- 									<Column xmlns="sap.ui.table" width="10%"> -->
+<!-- 										<Label text="Depth" xmlns="sap.ui.commons" /> -->
+<!-- 										<template> -->
+<!-- 											<TextView xmlns="sap.ui.commons" -->
+<!-- 												text="{ -->
+<!-- 		 												path: 'parent', -->
+<!-- 		 												formatter: 'model.Formatter.parentDepth'}"></TextView> -->
+<!-- 										</template> -->
+<!-- 									</Column> -->
 									<Column xmlns="sap.ui.table" width="10%" sorted="true"
 										sortProperty="lib/wellknownDigest">
 										<multiLabels>


### PR DESCRIPTION
until we do not collect also "own" dependencies (deps on modules of the same applications) we cannot show the depth as we do not store the entire list of parents but only the "external ones" (we skip own dependencies)

- [ ] Tests
- [ ] Documentation