### PR TITLE
Only add dependency parents accepted by the ArchiveAnalysisManager

### DIFF
--- a/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/ArchiveAnalysisManager.java
@@ -1,5 +1,6 @@
 package com.sap.psr.vulas.java;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,6 +24,7 @@ import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.shared.json.model.Application;
 import com.sap.psr.vulas.shared.json.model.Dependency;
 import com.sap.psr.vulas.shared.util.FileSearch;
+import com.sap.psr.vulas.shared.util.FileUtil;
 import com.sap.psr.vulas.shared.util.StopWatch;
 import com.sap.psr.vulas.shared.util.VulasConfiguration;
 
@@ -91,6 +93,19 @@ public class ArchiveAnalysisManager {
 	public void setIncludeDir(Path _p) {
 		this.inclDir = _p;
 		ArchiveAnalysisManager.log.info("Include dir set to [" + _p + "]");
+	}
+	
+	public static String[] getSupportedFileExtensions() { return new String[] { "jar", "war", "aar" }; }
+
+	public static final boolean canAnalyze(File _file) {
+		final String ext = FileUtil.getFileExtension(_file);
+		if(ext == null || ext.equals(""))
+			return false;
+		for(String supported_ext: getSupportedFileExtensions()) {
+			if(supported_ext.equalsIgnoreCase(ext))
+				return true;
+		}
+		return false;
 	}
 
 	/**

--- a/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/AbstractVulasMojo.java
+++ b/plugin-maven/src/main/java/com/sap/psr/vulas/mvn/AbstractVulasMojo.java
@@ -1,5 +1,6 @@
 package com.sap.psr.vulas.mvn;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -16,13 +17,13 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 import com.sap.psr.vulas.core.util.CoreConfiguration;
 import com.sap.psr.vulas.goals.AbstractAppGoal;
 import com.sap.psr.vulas.goals.GoalExecutionException;
+import com.sap.psr.vulas.java.ArchiveAnalysisManager;
 import com.sap.psr.vulas.shared.enums.GoalClient;
 import com.sap.psr.vulas.shared.enums.Scope;
 import com.sap.psr.vulas.shared.json.model.Application;
@@ -259,12 +260,13 @@ public abstract class AbstractVulasMojo extends AbstractMojo {
 
                 // Create dependency and put into map
                 dep = new Dependency(this.goal.getGoalContext().getApplication(), lib, Scope.fromString(a.getScope().toUpperCase(), Scope.RUNTIME), !direct_artifacts.contains(a), null, a.getFile().toPath().toString());
-                
+                                
                 // Set parent dependency (if there is any and it is NOT an intra-project Maven dependency with path target/classes)
                 final LibraryId parent = this.getParent(a.getDependencyTrail());
                 if(parent!=null) {
                 	for(Dependency parent_dep: dep_for_path.values()) {
-                		if(parent_dep.getLib().getLibraryId().equals(parent) && !Paths.get(parent_dep.getPath()).toFile().isDirectory()) {
+                		final File artifact_file = Paths.get(parent_dep.getPath()).toFile();
+                		if(parent_dep.getLib().getLibraryId().equals(parent) && !artifact_file.isDirectory() && ArchiveAnalysisManager.canAnalyze(artifact_file)) {
                 			dep.setParent(parent_dep);
                 			break;
                 		}


### PR DESCRIPTION
<!-- Describe your contribution -->

Fixes a bug related to dependencies of type `pom`, which resulted in the failure of application uploads.

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [X] Tests
- [ ] Documentation