### PR TITLE
improved performances for vulns in bundled libs

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/DependencyRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/DependencyRepository.java
@@ -3,7 +3,6 @@ package com.sap.psr.vulas.backend.repo;
 
 import java.util.List;
 
-import javax.validation.constraints.Null;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -92,7 +91,10 @@ public interface DependencyRepository extends PagingAndSortingRepository<Depende
 	List<Dependency> findWithBundledByApp(@Param("app") Application app);
 	
 	
-	@Query("SELECT distinct dep FROM Dependency dep JOIN FETCH dep.lib l JOIN FETCH l.bundledLibraryIds lb WHERE dep.app = :app AND lb IS NOT NULL AND NOT (SIZE(l.bundledLibraryIds)=1 AND l.libraryId MEMBER OF l.bundledLibraryIds) ")
+	@Query("SELECT distinct dep FROM Dependency dep "
+			+ "  JOIN FETCH dep.lib l "
+			+ "  JOIN FETCH l.bundledLibraryIds lb "
+			+ "  WHERE dep.app = :app AND lb IS NOT NULL AND NOT (SIZE(l.bundledLibraryIds)=1 AND l.libraryId MEMBER OF l.bundledLibraryIds) ")
 	List<Dependency> findWithDifferentBundledLibByApp(@Param("app") Application app);
 	
 }

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryIdRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryIdRepository.java
@@ -1,7 +1,6 @@
 package com.sap.psr.vulas.backend.repo;
 
 
-import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.Query;
@@ -9,14 +8,17 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.sap.psr.vulas.backend.model.Application;
 import com.sap.psr.vulas.backend.model.LibraryId;
-import com.sap.psr.vulas.backend.model.Property;
 import com.sap.psr.vulas.backend.util.ResultSetFilter;
 
 @Repository
 public interface LibraryIdRepository extends CrudRepository<LibraryId, Long> {
 
 	public static final ResultSetFilter<LibraryId> FILTER = new ResultSetFilter<LibraryId>();
+
+	@Query("SELECT l FROM LibraryId l WHERE l.id=:id")
+	List<LibraryId> findById(@Param("id") Long id);
 	
 	@Query("SELECT libid FROM LibraryId AS libid WHERE libid.mvnGroup = :mvnGroup AND libid.artifact = :artifact AND libid.version = :version")
 	List<LibraryId> findBySecondaryKey(@Param("mvnGroup") String mvnGroup, @Param("artifact") String artifact, @Param("version") String version);
@@ -29,4 +31,11 @@ public interface LibraryIdRepository extends CrudRepository<LibraryId, Long> {
 	
 	@Query("SELECT distinct libid FROM LibraryId AS libid where not libid.mvnGroup LIKE 'com.sap%'")
 	List<LibraryId> findAllLibIdsOSSI();
+	
+	@Query(value="select distinct d.id as dep_id, bl.bundled_library_ids_id as boundled_lid_id "
+			+ "   from app_dependency d "
+			+ "   inner join lib l1 on d.lib=l1.digest "
+			+ "   inner join lib_bundled_library_ids bl on l1.id=bl.library_id "
+			+ "   where d.app=:app and not l1.library_id_id = bl.bundled_library_ids_id  ", nativeQuery=true)
+	List<Object[]> findBundledLibIdByApp(@Param("app") Application app);
 }

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.sap.psr.vulas.backend.model.AffectedConstructChange;
+import com.sap.psr.vulas.backend.model.Application;
 import com.sap.psr.vulas.backend.model.Bug;
 import com.sap.psr.vulas.backend.model.ConstructId;
 import com.sap.psr.vulas.backend.model.Library;
@@ -210,5 +211,13 @@ public interface LibraryRepository extends CrudRepository<Library, Long>, Librar
 
 	@Query("SELECT l FROM Library l WHERE l.libraryId =:bundledLibId")
 	List<Library> findByLibraryId(@Param("bundledLibId") LibraryId bundledLibId);
+
+	@Query(value="select distinct d.id as dep_id, l2.id as bundled_lib_id"
+			+ "   from app_dependency d "
+			+ "   inner join lib l1 on d.lib=l1.digest "
+			+ "   inner join lib_bundled_library_ids bl on l1.id=bl.library_id "
+			+ "   inner join lib l2 on bl.bundled_library_ids_id=l2.library_id_id "
+			+ "   where d.app=:app and not l1.id = l2.id and l2.wellknown_digest='true'  ", nativeQuery=true)
+	List<Object[]> findBundledLibByApp(@Param("app") Application app);
 
 }


### PR DESCRIPTION
The query for vulndeps considering vulns affecting bundled libraries was too slow. In the previous implementation the logic was mostly implemented in Java and queries were performed to the db to get the required information, e.g., dependencies w/ bundled libs, libraries corresponding to the rebundled libs (known by GAV), etc.

In this new version, the performance improvement is given by the fact that the logic was pushed to the db using native queries to:

1) directly retrieve the libs (digests) corresponding to GAVs rebundled in some dependencies of an application
2) directly retrieve the library ids (gavs) corresponding to those rebundled in some dependencies of an application


- [x] Tested
- [ ] Documentation