### PR TITLE
fix(shared): handle a case of file name with dots

### DIFF
--- a/shared/src/main/java/com/sap/psr/vulas/shared/util/FileUtil.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/util/FileUtil.java
@@ -166,8 +166,8 @@ public class FileUtil {
 		if(idx!=-1) n = n.substring(idx+1);
 
 		// Remove file extension
-		if(!_keep_ext && n.indexOf(".")!=-1)
-			n = n.substring(0, n.indexOf("."));
+		if(!_keep_ext && n.lastIndexOf(".")!=-1)
+			n = n.substring(0, n.lastIndexOf("."));
 
 		return n;
 	}

--- a/shared/src/test/java/com/sap/psr/vulas/shared/util/FileUtilTest.java
+++ b/shared/src/test/java/com/sap/psr/vulas/shared/util/FileUtilTest.java
@@ -64,4 +64,17 @@ public class FileUtilTest {
 		final Set<String> jars = FileUtil.getJarFilePaths((URLClassLoader)FileUtil.class.getClassLoader());
 		assertTrue(!jars.isEmpty());
 	}
+
+	@Test
+	public void testGetFileName() {
+		final String name1 = FileUtil.getFileName("hello.min.js", false);
+		assertEquals("hello.min", name1);
+
+		final String name2 = FileUtil.getFileName("hello.js", false);
+		assertEquals("hello", name2);
+
+		final String name3 = FileUtil.getFileName(Paths.get("./project/js/hello.io.min.js").toString(), false);
+		assertEquals("hello.io.min", name3);
+	}
+
 }


### PR DESCRIPTION
<!-- Describe your contribution -->
Fix a case that FileUtil.getFileName returns a wrong file name without an extension if a name contains dots.

**Input:** /project/js/hello.io.min.js
**Expression:** FileUtil.getFileName("/project/js/hello.io.min.js", false);
**Expected Output:** hello.io.min

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [x] Tests
- [ ] Documentation