### PR TITLE
Propagate manual assessments for bugs w/o changes

### DIFF
--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/utils/CSVHelper2.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval/utils/CSVHelper2.java
@@ -148,10 +148,10 @@ public class CSVHelper2 {
              sb.append(COMMA_DELIMITER);
              if(cpr.getVulnAst()!=null){
              	String path = File.separator+"asts" + File.separator  
-             			+bugId+"_vulnAst_"+cpr.getQname().replace('*', '-') + "_" + getShortRepoPathName(cpr.getPath()).replace('/', '-') + ".txt";
+             			+bugId+"_vulnAst_"+cpr.getQname().replaceAll("[^a-zA-Z0-9\\._]+", "-") + "_" + getShortRepoPathName(cpr.getPath()).replaceAll("[^a-zA-Z0-9\\._]+", "-") + ".txt";
              	if(path.length()>260){
              		path = (File.separator+"asts" + File.separator  
-                 			+bugId+"_vulnAst_"+cpr.getQname().replace('*', '-') + "_" + getShortRepoPathName(cpr.getPath()).replace('/', '-')).substring(0, 200) + ".txt";
+                 			+bugId+"_vulnAst_"+cpr.getQname().replaceAll("[^a-zA-Z0-9\\._]+", "-") + "_" + getShortRepoPathName(cpr.getPath()).replaceAll("[^a-zA-Z0-9\\._]+", "-")).substring(0, 200) + ".txt";
              	}
              	File astV =  new File(PEConfiguration.getBaseFolder().toString()+path);
              	if(!astV.exists()){
@@ -162,10 +162,10 @@ public class CSVHelper2 {
              sb.append(COMMA_DELIMITER);
              if(cpr.getFixedAst()!=null) {
              	String path =  File.separator+"asts"+File.separator  +
-             			bugId+"_fixedAst_"+cpr.getQname().replace('*', '-') + "_" + getShortRepoPathName(cpr.getPath()).replace('/', '-')+".txt";
+             			bugId+"_fixedAst_"+cpr.getQname().replaceAll("[^a-zA-Z0-9\\._]+", "-") + "_" + getShortRepoPathName(cpr.getPath()).replaceAll("[^a-zA-Z0-9\\._]+", "-")+".txt";
              	if(path.length()>260){
              		path = ( File.separator+"asts"+File.separator  
-                 			+bugId+"_fixedAst_"+cpr.getQname().replace('*', '-') + "_" + getShortRepoPathName(cpr.getPath()).replace('/', '-')).substring(0, 200) + ".txt";
+                 			+bugId+"_fixedAst_"+cpr.getQname().replaceAll("[^a-zA-Z0-9\\._]+", "-") + "_" + getShortRepoPathName(cpr.getPath()).replaceAll("[^a-zA-Z0-9\\._]+", "-")).substring(0, 200) + ".txt";
              	}
              	File astF =  new File(PEConfiguration.getBaseFolder().toString()+path);
               	if(!astF.exists()){

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
@@ -905,6 +905,7 @@ public class BugLibManager {
         
     }
     
+    //this method is used for bugs without construct changes to propagate manual (and already propagated) assessments (affected-false) to newer versions within the same major release
     private void computeAndUploadPropagateResults() throws BackendConnectionException{
     	List<AffectedLibrary> existingManual = new ArrayList<AffectedLibrary>();
 		existingManual.addAll(Arrays.asList(BackendConnector.getInstance().getBugAffectedLibraries(bugChangeList.getBugId(),AffectedVersionSource.MANUAL.toString())));
@@ -979,19 +980,21 @@ public class BugLibManager {
 				}
 			}			
 		}
-		BugLibManager.log.info("Propagating results for [" + propagate + "] artifacts.");
-		if (VulasConfiguration.getGlobal().getConfiguration().getBoolean(PEConfiguration.UPLOAD_RESULTS) == true) {
-			BackendConnector.getInstance().uploadPatchEvalResults(bugChangeList.getBugId(),sourceResult.toString(), source);
-		} else {
-			// save to file
-
-			final File json_file = Paths.get(PEConfiguration.getBaseFolder().toString() + File.separator+ bugChangeList.getBugId() + "_" + source + "_" + ".json").toFile();
-			try {
-				FileUtil.writeToFile(json_file, sourceResult.toString());
-			} catch (IOException exception) {
-				exception.printStackTrace();
+		BugLibManager.log.info("Propagated results for [" + propagate + "] artifacts.");
+		if(propagate>0){
+			if (VulasConfiguration.getGlobal().getConfiguration().getBoolean(PEConfiguration.UPLOAD_RESULTS) == true) {
+				BackendConnector.getInstance().uploadPatchEvalResults(bugChangeList.getBugId(),sourceResult.toString(), source);
+			} else {
+				// save to file
+	
+				final File json_file = Paths.get(PEConfiguration.getBaseFolder().toString() + File.separator+ bugChangeList.getBugId() + "_" + source + "_" + ".json").toFile();
+				try {
+					FileUtil.writeToFile(json_file, sourceResult.toString());
+				} catch (IOException exception) {
+					exception.printStackTrace();
+				}
+				log.info("Results for source PROPAGATE_MANUAL written to [" + json_file + "]");
 			}
-			log.info("Results for source PROPAGATE_MANUAL written to [" + json_file + "]");
 		}
 
     }

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
@@ -12,6 +12,7 @@ import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -45,6 +46,7 @@ import com.sap.psr.vulas.shared.json.model.AffectedLibrary;
 import com.sap.psr.vulas.shared.json.model.Artifact;
 import com.sap.psr.vulas.shared.json.model.BugChangeList;
 import com.sap.psr.vulas.shared.json.model.ConstructChange;
+import com.sap.psr.vulas.shared.json.model.Library;
 import com.sap.psr.vulas.shared.json.model.LibraryId;
 import com.sap.psr.vulas.shared.json.model.Version;
 import com.sap.psr.vulas.shared.json.model.metrics.Counter;
@@ -810,23 +812,30 @@ public class BugLibManager {
 					BugLibManager.log.error("Error getting bug; the bug [" + bug.getBugId() + "] does not exist in the backend");
 	        	}
 	        	else{
-	        		boolean mod_exists=false;
+	        		boolean mod_exists = false;
+	        		boolean no_cc = false;
 	        	
+	        		if(b.getConstructChanges()!=null && b.getConstructChanges().isEmpty()){
+	        			no_cc=true;
+	        			BugLibManager.log.info("Bug ["+b.getBugId()+"] does not have any construct change, we still continue to propagate the MANUAL results.");
+	        		}
+	        		//the following loop and subsequent if on mod_exists are not really needed any longer as, not matter the result, we still proceed with the analysis. For now they are still present to provide the logging info
 	        		for(ConstructChange c: b.getConstructChanges()){
 	        			if((c.getConstructId().getType().equals(ConstructType.CONS)||c.getConstructId().getType().equals(ConstructType.METH))&&c.getConstructChangeType().equals(ConstructChangeType.MOD)){
 	        				mod_exists=true;
-	        				BugLibManager.log.info("At least one MOD constructor/method for bug ["+b.getBugId()+"] exists, continue patchEval");
+	        				BugLibManager.log.info("At least one MOD constructor/method for bug ["+b.getBugId()+"] exists.");
 	        				break;
 	        			}
-	        		}if(!mod_exists){
-	        			BugLibManager.log.info("No-MOD constructor/method for bug ["+b.getBugId()+"] exists, we still continue to propagate the MANUAL results.");
-	        			mod_exists=true;
 	        		}
-	        		if(mod_exists){	
+	        		if(!mod_exists){
+	        			BugLibManager.log.info("No-MOD constructor/method for bug ["+b.getBugId()+"] exists, we still continue to propagate the MANUAL results.");
+	        		}
 	        		
-			        	bm.resetToBug(b);
-				        File f = bm.getCsv();
-				        bla.setBug(b);
+	        		bm.resetToBug(b);
+			        File f = bm.getCsv();
+			        bla.setBug(b);
+	        		
+	        		if(!no_cc){				        	
 				        
 				      //if CSV does not exist, create it
 				        if (f==null){
@@ -872,9 +881,10 @@ public class BugLibManager {
 				        
 				    //    bm.computeGA();
 				      	bm.computeAndUploadResults();
+		        		
 	        		}
 	        		else{
-	        			log.info("Bug [" + b.getBugId() + " does not include any MOD construct, skip patch Eval.");
+	        			bm.computeAndUploadPropagateResults();    	     
 	        		}
 	        	}
 	            log.info("###################################################################");
@@ -893,6 +903,94 @@ public class BugLibManager {
         }
 
         
+    }
+    
+    private void computeAndUploadPropagateResults() throws BackendConnectionException{
+    	List<AffectedLibrary> existingManual = new ArrayList<AffectedLibrary>();
+		existingManual.addAll(Arrays.asList(BackendConnector.getInstance().getBugAffectedLibraries(bugChangeList.getBugId(),AffectedVersionSource.MANUAL.toString())));
+		existingManual.addAll(Arrays.asList(BackendConnector.getInstance().getBugAffectedLibraries(bugChangeList.getBugId(),AffectedVersionSource.PROPAGATE_MANUAL.toString())));
+    	
+		BugLibManager.log.info("Existing [" + existingManual.size() + "] affected libraries in backend for sources MANUAL and PROPAGATE_MANUAL.");
+		
+        List<String> groupsArtifactsToCheck = new ArrayList<>();
+		List<Artifact> gavToBeAssessed = new ArrayList<Artifact>();
+		List<Artifact> gavAssessed = new ArrayList<Artifact>();
+        for (AffectedLibrary al : existingManual){
+            if ( al.getLibraryId() != null ){
+            	String ga = al.getLibraryId().getMvnGroup() + ":" + al.getLibraryId().getArtifact();
+            	gavAssessed.add(new Artifact(al.getLibraryId().getMvnGroup(),al.getLibraryId().getArtifact(),al.getLibraryId().getVersion()));
+            	if(!groupsArtifactsToCheck.contains(ga) ){
+            		groupsArtifactsToCheck.add(ga);
+            		Artifact[] artifactsLibraries = BackendConnector.getInstance().getAllArtifactsGroupArtifact(al.getLibraryId().getMvnGroup(), al.getLibraryId().getArtifact());
+            		if ( artifactsLibraries != null ){
+                        for ( Artifact a : artifactsLibraries){
+                        	if ( !gavToBeAssessed.contains(a) ){
+                        		gavToBeAssessed.add(a);
+	                   	 	}
+                        }
+            		}
+            	}
+            }
+        }
+		
+		
+		//add artifactResult to propagate_manual
+		String source = "PROPAGATE_MANUAL";
+		boolean isGreater=false,isSmaller=false;
+		int propagate=0;
+		JsonArray sourceResult = new JsonArray();
+		
+		//TODO remove existing gavs from list of tobeassessed
+		for(Artifact a : gavToBeAssessed){
+
+			isGreater=false;
+			isSmaller=false;
+			for(AffectedLibrary i :existingManual){
+				if(i.getLibraryId()!=null && i.getLibraryId().getMvnGroup().equals(a.getLibId().getMvnGroup()) && 
+						i.getLibraryId().getArtifact().equals(a.getLibId().getArtifact()) ){
+					Version toCompare = new Version(i.getLibraryId().getVersion());
+					Version current = new Version(a.getLibId().getVersion());
+					
+					if(current.getMaintenanceRelease().equals(toCompare.getMaintenanceRelease()) ||
+							toCompare.isMaintenanceRelease()){
+						if(current.compareTo(toCompare)==0){
+							isGreater=false;
+							break;
+						}
+						else if (!i.getAffected() && current.compareTo(toCompare)>0){
+							isGreater=true;
+						}
+						else if (i.getAffected() && current.compareTo(toCompare)<0){
+							isSmaller=true;
+						}
+					}
+				}
+			}
+			
+			if(isGreater&&!isSmaller){
+				propagate++;
+				log.info("Creating Json for PROPAGATE_MANUAL for artifact [" + a.toString()+"]");
+				JsonObject result = createJsonResult(a, source, false);
+				
+				sourceResult.add(result);
+			}
+			
+		}
+		BugLibManager.log.info("Propagating results for [" + propagate + "] artifacts.");
+		if (VulasConfiguration.getGlobal().getConfiguration().getBoolean(PEConfiguration.UPLOAD_RESULTS) == true) {
+			BackendConnector.getInstance().uploadPatchEvalResults(bugChangeList.getBugId(),sourceResult.toString(), source);
+		} else {
+			// save to file
+
+			final File json_file = Paths.get(PEConfiguration.getBaseFolder().toString() + File.separator+ bugChangeList.getBugId() + "_" + source + "_" + ".json").toFile();
+			try {
+				FileUtil.writeToFile(json_file, sourceResult.toString());
+			} catch (IOException exception) {
+				exception.printStackTrace();
+			}
+			log.info("Results for source PROPAGATE_MANUAL written to [" + json_file + "]");
+		}
+
     }
     
     private void compareBytecode() {
@@ -937,7 +1035,7 @@ public class BugLibManager {
 		//CSVHelper2.rewriteCSV(bugChangeList.getBugId(), lids);
 				
 	}
-
+    
 	private File getCsv(){
     	String baseFolder = PEConfiguration.getBaseFolder().toString();
         File containingFolder = new File(baseFolder);
@@ -1138,6 +1236,19 @@ public class BugLibManager {
 			result.addProperty("adpathfixed", a.isPathADFixed());
 		}
 		result.add("affectedcc", a.getAffectedcc(methsConsCC));
+		return result;
+    }
+    
+    private JsonObject createJsonResult(Artifact a, String s, Boolean affected){
+		JsonObject result = new JsonObject();
+		result.addProperty("source", s);
+		if(affected!=null)
+			result.addProperty("affected", affected);
+		JsonObject libraryId = new JsonObject();
+		libraryId.addProperty("group", a.getLibId().getMvnGroup());
+		libraryId.addProperty("artifact", a.getLibId().getArtifact());
+		libraryId.addProperty("version", a.getLibId().getVersion());
+		result.add("libraryId", libraryId);
 		return result;
     }
 


### PR DESCRIPTION
Added to patch-lib-analyzer to propagate existing manual assessments (affected=false) for bug w/o construct changes (until now it was done for bug w/ construct changes even if no MOD methods/constructors was present). The propagation is done for library ids whose version:

- is greater than the one of a library ids assessed as NOT affected,
- and is not smaller than the one of a library ids assessed as affected.

- [x] Tested locally
- [ ] Documentation