### PR TITLE
added comparison on path to Dependency.compareTo

### DIFF
--- a/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Dependency.java
+++ b/shared/src/main/java/com/sap/psr/vulas/shared/json/model/Dependency.java
@@ -288,13 +288,15 @@ public class Dependency implements Serializable, Comparable<Dependency> {
 	 * library identifiers and filenames.
 	 */
 	@Override
-	public int compareTo(Dependency _other) {		
+	public int compareTo(Dependency _other) {	
 		if(_other.isParent(this))
 			return -1;
 		else if(this.isParent(_other))
 			return +1;
 		else {
-			if(this.getFilename()!=null && _other.getFilename()!=null) {
+			if(this.getPath()!=null && _other.getPath()!=null){
+				return this.getPath().compareTo(_other.getPath());
+			} else if(this.getFilename()!=null && _other.getFilename()!=null) {
 				return this.getFilename().compareTo(_other.getFilename());
 			} else if(this.getLib().getDigest()!=null && _other.getLib().getDigest()!=null) {
 				return this.getLib().getDigest().compareTo(_other.getLib().getDigest());


### PR DESCRIPTION
The existing compareTo was not properly handling dependencies with same filename but different LibraryId (and thereby residing in different paths). As a consequence just one was added to the list of dependencies of an application and if the one left out was used as a parent an invalid Json was posted to the backend.

The new compareTo ensures that both dependencies are added to the application's dependency list


- [ x] Tested locally
- [ ] Documentation