### PR TITLE
in case of backend exception; proceed with next vuln

### DIFF
--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/BugLibManager.java
@@ -812,7 +812,7 @@ public class BugLibManager {
      * @throws com.sap.psr.vulas.backend.BackendConnectionException if any.
      * @throws java.lang.InterruptedException if any.
      */
-    public static void analyze(List<Bug> bugsToAnalyze) throws BackendConnectionException, InterruptedException{
+    public static void analyze(List<Bug> bugsToAnalyze) throws InterruptedException{
         
     	//necessary read_write as the ast_diff is done using POST
 		VulasConfiguration.getGlobal().setProperty(CoreConfiguration.BACKEND_CONNECT, CoreConfiguration.ConnectType.READ_WRITE.toString());
@@ -902,19 +902,26 @@ public class BugLibManager {
 	        			bm.computeAndUploadPropagateResults();    	     
 	        		}
 	        	}
-	            log.info("###################################################################");
-	            log.info("*******************************************************************");
-	            log.info("BUG [" + bug.getBugId() + "] analyzed.");
-	            log.info("Status: " + (count+1)+ "/" + bugsToAnalyze.size());
-	            log.info("*******************************************************************");
-	            log.info("###################################################################");
-			    count++;
+	           
 	        } catch (FileNotFoundException e) {
 				BugLibManager.log.error("CSV file not found : " + e);
 			} catch (IOException e) {
 				BugLibManager.log.error("Error reasding CSV file" + e);
 			
+			} catch (BackendConnectionException bce){
+				if(bce.getHttpResponseStatus()==503)
+					log.error("Service still unavailable (503) after 1h, could not analyze bugs");
+				else
+					BugLibManager.log.error("Cannot analyze bug [" +bug.getBugId()+ "], exception occurred. Cause : " + bce.getCause() );
+				Thread.sleep(10000);
 			}
+        	log.info("###################################################################");
+            log.info("*******************************************************************");
+            log.info("BUG [" + bug.getBugId() + "] completed.");
+            log.info("Status: " + (count+1)+ "/" + bugsToAnalyze.size());
+            log.info("*******************************************************************");
+            log.info("###################################################################");
+		    count++;
         }
 
         

--- a/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/PE_Run.java
+++ b/patch-lib-analyzer/src/main/java/com/sap/psr/vulas/patcheval2/PE_Run.java
@@ -88,10 +88,6 @@ public class PE_Run implements Runnable {
 
 		try {
 			BugLibManager.analyze(bugsToAnalyze);
-		} catch (BackendConnectionException e) {
-			if(e.getHttpResponseStatus()==503)
-				log.error("Service still unavailable (503) after 1h, could not analyze bugs");
-			e.printStackTrace();
 		} catch (InterruptedException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();


### PR DESCRIPTION
Improved patch-lib-analyzer to skip a single vulnerability (and proceed to analyze the remaining) in case anything goes wrong while connecting to the backend and lib-utils services.


- [x] Tested
- [ ] Documentation