### PR TITLE
Check for vuln in rebundled libids querying from LibraryIdController

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryIdRepository.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/repo/LibraryIdRepository.java
@@ -43,7 +43,7 @@ public interface LibraryIdRepository extends CrudRepository<LibraryId, Long> {
 	 * @param artifact a {@link java.lang.String} object.
 	 * @return a {@link java.util.List} object.
 	 */
-	@Query("SELECT distinct libid FROM LibraryId AS libid JOIN FETCH libid.affLibraries WHERE libid.mvnGroup = :mvnGroup AND libid.artifact = :artifact")
+	@Query("SELECT distinct libid FROM LibraryId AS libid JOIN FETCH libid.affLibraries  WHERE libid.mvnGroup = :mvnGroup AND libid.artifact = :artifact") 
 	List<LibraryId> findLibIds(@Param("mvnGroup") String mvnGroup, @Param("artifact") String artifact);
 	
 	/**
@@ -68,4 +68,11 @@ public interface LibraryIdRepository extends CrudRepository<LibraryId, Long> {
 			+ "   inner join lib_bundled_library_ids bl on l1.id=bl.library_id "
 			+ "   where d.app=:app and not l1.library_id_id = bl.bundled_library_ids_id  ", nativeQuery=true)
 	List<Object[]> findBundledLibIdByApp(@Param("app") Application app);
+	
+	@Query(value="select lid.id, bl.bundled_library_ids_id as boundled_lid_id "
+			+ "   from library_id lid "
+			+ "   inner join lib l1 on lid.id=l1.library_id_id "
+			+ "   inner join lib_bundled_library_ids bl on l1.id=bl.library_id "
+			+ "   where lid.mvn_group = :mvnGroup AND lid.artifact = :artifact and not l1.library_id_id = bl.bundled_library_ids_id  ", nativeQuery=true)
+	List<Object[]> findBundledLibIdByGA(@Param("mvnGroup") String mvnGroup, @Param("artifact") String artifact);
 }

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/LibraryIdController.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/LibraryIdController.java
@@ -186,8 +186,6 @@ public class LibraryIdController {
 			
 			//all libids rebundled in a libraryId having the given GA
 			List<Object[]> libids_w_rebundles = this.libIdRepository.findBundledLibIdByGA(mvnGroup, artifact);
-						
-			log.info("Found ["+libids_w_rebundles.size()+"] libids with rebundled libids.");
 			
 			for(Object[] e: libids_w_rebundles) {
 				//check whether the libId rebundles a vulnerable library. If so, add it to vuln_libids


### PR DESCRIPTION
The LibraryIdController when used to get vulnerable/non-vulnerable libraryIds, was not considering vulnerabilities in rebundled LibIds. As a consequence the mitigation tab of the web frontend would show as non-vulnerable a GAV that actually has vulnerabilities in some rebundled library.

- [x] Tested locally, and on test system
- [ ] Documentation