### PR TITLE
Removes the generation of postgres/haproxy images

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,19 +35,13 @@ services:
     container_name: vulnerability-assessment-tool-haproxy
     hostname: haproxy
     env_file: .env
-    build: 
-      context: ./haproxy
-      dockerfile: ./Dockerfile
-      args:
-        - VULAS_RELEASE=${VULAS_RELEASE}
-        - http_proxy=${http_proxy}
-        - https_proxy=${https_proxy}
-    image: vulnerability-assessment-tool-haproxy:${VULAS_RELEASE}
+    image: haproxy:alpine
     ports:
       - "8033:8080"
       - "8034:7070"
     volumes:
       - "./haproxy/conf/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg"
+    command: ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]
     depends_on:
       - frontend-apps
       - frontend-bugs
@@ -89,19 +83,17 @@ services:
   postgresql:
     container_name: vulnerability-assessment-tool-postgresql
     hostname: postgresql
-    build: 
-      context: ./postgresql
-      dockerfile: ./Dockerfile
-      args:
-        - VULAS_RELEASE=${VULAS_RELEASE}
-    image: vulnerability-assessment-tool-postgresql:${VULAS_RELEASE}
+    image: postgres:11-alpine
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=vulas
+      - PGDATA=/var/lib/postgresql/data
     ports:
       - "8032:5432"
     volumes:
       - vulnerability-assessment-tool-postgres-data:/var/lib/postgresql/data
+      - ./postgresql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:ro
     security_opt:
       - no-new-privileges
     restart: always

--- a/docker/haproxy/Dockerfile
+++ b/docker/haproxy/Dockerfile
@@ -1,5 +1,0 @@
-FROM haproxy:alpine
-
-LABEL maintainer="Vulas vulas-dev@listserv.sap.com"
-
-CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/docker/postgresql/Dockerfile
+++ b/docker/postgresql/Dockerfile
@@ -1,8 +1,0 @@
-FROM postgres:11-alpine
-
-LABEL maintainer="Vulas vulas-dev@listserv.sap.com"
-
-ENV POSTGRES_DB vulas
-ENV PGDATA /var/lib/postgresql/data
-
-COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/docker/push-images.sh
+++ b/docker/push-images.sh
@@ -17,15 +17,15 @@ fi
 REGISTRY_HOST=$1
 USERNAME=$2
 VERSION=$3
-SERVICES='generator frontend-apps frontend-bugs haproxy patch-lib-analyzer postgresql rest-backend rest-lib-utils'
+SERVICES='generator frontend-apps frontend-bugs patch-lib-analyzer rest-backend rest-lib-utils'
 
-docker login $REGISTRY_HOST
+docker login "$REGISTRY_HOST"
 
 VULAS_RELEASE=$VERSION docker-compose build
 
 for service in $SERVICES ;
 do
     IMAGE=${REGISTRY_HOST}/${USERNAME}/vulnerability-assessment-tool-$service:${VERSION}
-    docker tag vulnerability-assessment-tool-$service:${VERSION} $IMAGE
-    docker push ${IMAGE}
+    docker tag "vulnerability-assessment-tool-$service:${VERSION}" "$IMAGE"
+    docker push "${IMAGE}"
 done

--- a/docs/public/content/admin/tutorials/docker.md
+++ b/docs/public/content/admin/tutorials/docker.md
@@ -34,6 +34,12 @@ Before proceeding, be sure to move there with:
 cd vulnerability-assessment-tool
 ```
 
+If you want you can checkout a stable version of Vulas. Usually the `master` branch holds a `-SNAPSHOT` version.
+
+```sh
+git checkout tags/@@PROJECT_VERSION@@
+```
+
 Make a copy of the sample configuration:
 
 ```sh

--- a/docs/public/content/admin/tutorials/registry.md
+++ b/docs/public/content/admin/tutorials/registry.md
@@ -21,8 +21,6 @@ vulnerability-assessment-tool-rest-backend       @@PROJECT_VERSION@@ 277217bc35b
 vulnerability-assessment-tool-rest-lib-utils     @@PROJECT_VERSION@@ 53bbb929895d  22 hours ago 127MB
 vulnerability-assessment-tool-frontend-bugs      @@PROJECT_VERSION@@ fab5925fe785  22 hours ago 316MB
 vulnerability-assessment-tool-frontend-apps      @@PROJECT_VERSION@@ 191ce235c420  22 hours ago 317MB
-vulnerability-assessment-tool-haproxy            @@PROJECT_VERSION@@ 37948fae374e  22 hours ago 20.9MB
-vulnerability-assessment-tool-postgresql         @@PROJECT_VERSION@@ c7a17e4f4cda  22 hours ago 70.8MB
 ```
 
 ## Push the images to a registry


### PR DESCRIPTION
<!-- Describe your contribution -->
We now use directly `haproxy` and `postgres` images and we use `volumes` and `command`s to tune the container.

This contribution is toward automatically push images on Docker Hub.
<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [x] Documentation