### PR TITLE
Docker deployment rework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - docker build --tag vulnerability-assessment-tool-generator -f docker/Dockerfile --build-arg http_proxy= --build-arg https_proxy= .
     - docker run -it --rm -v ${PWD}/docker:/exporter -v ${PWD}/.travis/settings.xml:/settings.xml --env-file ./docker/.env -e mvn_flags='-q -P gradle -Dit.test=!IT01_PatchAnalyzerIT,IT*,*IT,*ITCase -DfailIfNoTests=false --settings /settings.xml' vulnerability-assessment-tool-generator
     script:
-    - "(cd docker && docker-compose up -d --build)"
+    - "(cd docker && docker-compose -f docker-compose.build.yml up -d --build)"
     - sh .travis/check.sh
     after_failure:
     - docker images
@@ -40,6 +40,7 @@ matrix:
       script: bash .travis/docker_hub_push_snapshot.sh
       on:
         branch: master
+        condition: $TRAVIS_EVENT_TYPE = push
     - provider: script
       skip_cleanup: true
       script: bash .travis/docker_hub_push_release.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - docker build --tag vulnerability-assessment-tool-generator -f docker/Dockerfile --build-arg http_proxy= --build-arg https_proxy= .
     - docker run -it --rm -v ${PWD}/docker:/exporter -v ${PWD}/.travis/settings.xml:/settings.xml --env-file ./docker/.env -e mvn_flags='-q -P gradle -Dit.test=!IT01_PatchAnalyzerIT,IT*,*IT,*ITCase -DfailIfNoTests=false --settings /settings.xml' vulnerability-assessment-tool-generator
     script:
-    - "(cd docker && docker-compose f docker-compose.yml -f docker-compose.build.yml up -d --build)"
+    - "(cd docker && docker-compose -f docker-compose.yml -f docker-compose.build.yml up -d --build)"
     - sh .travis/check.sh
     after_failure:
     - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - docker build --tag vulnerability-assessment-tool-generator -f docker/Dockerfile --build-arg http_proxy= --build-arg https_proxy= .
     - docker run -it --rm -v ${PWD}/docker:/exporter -v ${PWD}/.travis/settings.xml:/settings.xml --env-file ./docker/.env -e mvn_flags='-q -P gradle -Dit.test=!IT01_PatchAnalyzerIT,IT*,*IT,*ITCase -DfailIfNoTests=false --settings /settings.xml' vulnerability-assessment-tool-generator
     script:
-    - "(cd docker && docker-compose -f docker-compose.build.yml up -d --build)"
+    - "(cd docker && docker-compose f docker-compose.yml -f docker-compose.build.yml up -d --build)"
     - sh .travis/check.sh
     after_failure:
     - docker images

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -4,20 +4,16 @@ VULAS_ENV=prod
 
 # *** MANDATORY SETTINGS ***
 # PostgreSQL
-POSTGRES_USER=
-POSTGRES_PASSWORD=
-
-# Spring (should be equal to the values in PostgreSQL section above)
-spring.datasource.username=
-spring.datasource.password=
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=changeme
 
 # HAProxy
-HAPROXY_STATS_USER=
-HAPROXY_STATS_PASSWORD=
+HAPROXY_STATS_USER=haproxy
+HAPROXY_STATS_PASSWORD=changeme
 
 # Frontend Bugs Frontend
-FRONTEND_BUGS_USER=
-FRONTEND_BUGS_PASSWORD=
+FRONTEND_BUGS_USER=vulas
+FRONTEND_BUGS_PASSWORD=changeme
 
 # *** OPTIONAL SETTINGS ***
 # Jira (optional)

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -1,0 +1,42 @@
+version: '2'
+
+services:
+  frontend-apps:
+    build: 
+      context: ./frontend-apps
+      dockerfile: ./Dockerfile
+      args:
+        - VULAS_RELEASE=${VULAS_RELEASE}
+    image: vulnerability-assessment-tool-frontend-apps:${VULAS_RELEASE}
+
+  frontend-bugs:
+    build: 
+      context: ./frontend-bugs
+      dockerfile: ./Dockerfile
+      args:
+        - VULAS_RELEASE=${VULAS_RELEASE}
+    image: vulnerability-assessment-tool-frontend-bugs:${VULAS_RELEASE}
+
+  patch-lib-analyzer:
+    build: 
+      context: ./patch-lib-analyzer
+      dockerfile: ./Dockerfile
+      args:
+        - VULAS_RELEASE=${VULAS_RELEASE}
+    image: vulnerability-assessment-tool-patch-lib-analyzer:${VULAS_RELEASE}
+
+  rest-backend:
+    build: 
+      context: ./rest-backend    
+      dockerfile: ./Dockerfile
+      args:
+        - VULAS_RELEASE=${VULAS_RELEASE}
+    image: vulnerability-assessment-tool-rest-backend:${VULAS_RELEASE}
+
+  rest-lib-utils:
+    build: 
+      context: ./rest-lib-utils 
+      dockerfile: ./Dockerfile
+      args:
+        - VULAS_RELEASE=${VULAS_RELEASE}
+    image: vulnerability-assessment-tool-rest-lib-utils:${VULAS_RELEASE}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,12 +4,7 @@ services:
   frontend-apps:
     container_name: vulnerability-assessment-tool-frontend-apps
     hostname: frontend-apps
-    build: 
-      context: ./frontend-apps
-      dockerfile: ./Dockerfile
-      args:
-        - VULAS_RELEASE=${VULAS_RELEASE}
-    image: vulnerability-assessment-tool-frontend-apps:${VULAS_RELEASE}
+    image: vulas/vulnerability-assessment-tool-frontend-apps:${VULAS_RELEASE}
     expose:
       - "8080"
     security_opt:
@@ -19,12 +14,7 @@ services:
   frontend-bugs:
     container_name: vulnerability-assessment-tool-frontend-bugs
     hostname: frontend-bugs
-    build: 
-      context: ./frontend-bugs
-      dockerfile: ./Dockerfile
-      args:
-        - VULAS_RELEASE=${VULAS_RELEASE}
-    image: vulnerability-assessment-tool-frontend-bugs:${VULAS_RELEASE}
+    image: vulas/vulnerability-assessment-tool-frontend-bugs:${VULAS_RELEASE}
     expose:
       - "8080"
     security_opt:
@@ -54,14 +44,7 @@ services:
   patch-lib-analyzer:
     container_name: vulnerability-assessment-tool-patch-lib-analyzer
     hostname: patch-lib-analyzer
-    build: 
-      context: ./patch-lib-analyzer
-      dockerfile: ./Dockerfile
-      args:
-        - VULAS_RELEASE=${VULAS_RELEASE}
-        - http_proxy=${http_proxy}
-        - https_proxy=${https_proxy}
-    image: vulnerability-assessment-tool-patch-lib-analyzer:${VULAS_RELEASE}
+    image: vulas/vulnerability-assessment-tool-patch-lib-analyzer:${VULAS_RELEASE}
     expose:
       - "8080"
     volumes:
@@ -104,14 +87,7 @@ services:
     env_file: 
       - .env
       - ./rest-backend/conf/restbackend.properties
-    build: 
-      context: ./rest-backend    
-      dockerfile: ./Dockerfile
-      args:
-        - VULAS_RELEASE=${VULAS_RELEASE}
-        - http_proxy=${http_proxy}
-        - https_proxy=${https_proxy}
-    image: vulnerability-assessment-tool-rest-backend:${VULAS_RELEASE}
+    image: vulas/vulnerability-assessment-tool-rest-backend:${VULAS_RELEASE}
     expose:
       - "8091"
     environment:
@@ -135,14 +111,7 @@ services:
   rest-lib-utils:
     container_name: vulnerability-assessment-tool-rest-lib-utils
     hostname: rest-lib-utils
-    build: 
-      context: ./rest-lib-utils 
-      dockerfile: ./Dockerfile
-      args:
-        - VULAS_RELEASE=${VULAS_RELEASE}
-        - http_proxy=${http_proxy}
-        - https_proxy=${https_proxy}
-    image: vulnerability-assessment-tool-rest-lib-utils:${VULAS_RELEASE}
+    image: vulas/vulnerability-assessment-tool-rest-lib-utils:${VULAS_RELEASE}
     expose:
         - "8092"
     volumes:

--- a/docker/push-images.sh
+++ b/docker/push-images.sh
@@ -58,7 +58,7 @@ fi
 
 SERVICES='frontend-apps frontend-bugs patch-lib-analyzer rest-backend rest-lib-utils'
 
-VULAS_RELEASE=${VULAS_RELEASE} docker-compose build
+VULAS_RELEASE=${VULAS_RELEASE} docker-compose -f docker-compose.build.yml build
 
 if [[ "$(docker images -q vulnerability-assessment-tool-rest-backend:"$VULAS_RELEASE" 2> /dev/null)" == "" ]]; then
     echo "[-] There are no local images for release $VULAS_RELEASE"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
     - DevOps: 'admin/index.md'
     - Tutorials: 
       - 'Deploy on Docker': 'admin/tutorials/docker.md'
+      - 'Build JAVA archives/Docker images': 'admin/tutorials/build.md'
       - 'Push Docker images to a registry': 'admin/tutorials/registry.md'
   - Contribute:
     - Contribute: contributor/index.md

--- a/docs/public/content/admin/index.md
+++ b/docs/public/content/admin/index.md
@@ -5,4 +5,5 @@
 **Important**: Due to the current lack of an authorization concept, we do not advise to expose an instance of @@PROJECT_NAME@@ to the Internet.
 
 - [Deploy on Docker](./tutorials/docker/) and [Import the knowledge base](../vuln_db/tutorials/vuln_db_tutorial/#batch-import-from-knowledge-base)
+- [Build JAVA archives and local Docker images](./tutorials/build/)
 - [Push Docker images to a registry](./tutorials/registry/)

--- a/docs/public/content/admin/tutorials/build.md
+++ b/docs/public/content/admin/tutorials/build.md
@@ -1,0 +1,66 @@
+# Building Docker images from source
+
+## Pre-requisites
+
+- git
+- docker
+- docker-compose
+
+## Customization
+
+All the following commands are supposed to be executed from the root folder of the project.
+
+If you want to build images specific to a version you can checkout a stable version of Vulas. Usually the `master` branch holds a `-SNAPSHOT` version.
+
+```sh
+git checkout tags/@@PROJECT_VERSION@@
+```
+
+Make a copy of the sample configuration:
+
+```sh
+cp docker/.env.sample docker/.env
+```
+
+Customize the file `docker/.env` to match your needs, make sure you set the version you want to build in VULAS_RELEASE.
+
+> In `docker/.env` you must configure at least `POSTGRES_USER=`, you should also configure the `HAPROXY`'s user and password as well as the credentials to access the bugs' frontend
+
+## Generate JAVA archives
+
+At this point, you are ready to build the JAR/WAR artifacts with the following command:
+
+```sh
+docker build --tag vulnerability-assessment-tool-generator:@@PROJECT_VERSION@@ -f docker/Dockerfile .
+docker run -it --rm -v ${PWD}/docker:/exporter --env-file ./docker/.env -e mvn_flags=-DskipTests vulnerability-assessment-tool-generator:@@PROJECT_VERSION@@
+```
+
+> If the command above fails, add `-DreuseForks=False` flag to `mvn_flags`. As shown in the example below.
+>
+> ```sh
+> docker run -it --rm -v ${PWD}/docker:/exporter --env-file ./docker/.env -e mvn_flags='-DskipTests -DreuseForks=False' vulnerability-assessment-tool-generator:@@PROJECT_VERSION@@
+> ```
+
+> In case you are running behind a proxy you need to configure it in the `--build-arg` arguments. Check the [predefined `ARG`s](https://docs.docker.com/engine/reference/builder/#predefined-args) documentation to know more.
+
+As a result, the folders `docker/<component-name>` will contain compiled JARs (or WARs, depending on the component). The folder `docker/client-tools` will be populated with the JARs for client side tools (CLI, plugins, patchanalyzer).
+
+Additionally, you may want to make the artifacts available to the developers of your organization (e.g., through an internal Nexus or other artifact distribution system).
+
+## Generate Docker images
+
+You are now ready to run the system with the generated archives and create the Docker images:
+
+```sh
+(cd docker && docker-compose -f docker-compose.build.yml build)
+```
+
+You can create and run containers from the generated images.
+
+```sh
+(cd docker && docker-compose -f docker-compose.build.yml up -d)
+```
+
+To check everything started successfully, browse the page `http://localhost:8033/haproxy?stats`. All endpoints should appear as green.
+
+> `username` and `password` can be found in your `.env` file, be also advised that `rest-backend` could take more than 30 seconds to be ready to answer HTTP requests

--- a/docs/public/content/admin/tutorials/build.md
+++ b/docs/public/content/admin/tutorials/build.md
@@ -58,7 +58,7 @@ You are now ready to run the system with the generated archives and create the D
 You can create and run containers from the generated images.
 
 ```sh
-(cd docker && docker-compose -f docker-compose.build.yml up -d)
+(cd docker && docker-compose f docker-compose.yml -f docker-compose.build.yml up -d)
 ```
 
 To check everything started successfully, browse the page `http://localhost:8033/haproxy?stats`. All endpoints should appear as green.

--- a/docs/public/content/admin/tutorials/docker.md
+++ b/docs/public/content/admin/tutorials/docker.md
@@ -16,62 +16,25 @@ In this tutorial you will be guided through the necessary steps to set-up the @@
 
 - git
 - docker
+- docker-compose
 
 ## Installation
 
-### Clone from GitHub
+### Setup
+
+Clone locally the `vulnerability-assessment-tool` repository
 
 ```sh
 git clone https://github.com/SAP/vulnerability-assessment-tool
 ```
 
-### Build Docker images
-
-All the following commands are supposed to be executed from the root folder of the project.
-Before proceeding, be sure to move there with:
-
-```sh
-cd vulnerability-assessment-tool
-```
-
-If you want you can checkout a stable version of Vulas. Usually the `master` branch holds a `-SNAPSHOT` version.
-
-```sh
-git checkout tags/@@PROJECT_VERSION@@
-```
-
-Make a copy of the sample configuration:
+Customize the file `docker/.env` to match your needs, make sure you set the version you want to run in VULAS_RELEASE.
 
 ```sh
 cp docker/.env.sample docker/.env
 ```
 
-Customize the file `docker/.env` to match your needs.
-
-!!! info "Sensitive information"
-
-	In `docker/.env` you must configure at least `POSTGRES_USER=`, you should also configure the `HAPROXY`'s user and password as well as the credentials to access the bugs' frontend
-
-At this point, you are ready to perform the actual build with the following command:
-
-```sh
-docker build --tag vulnerability-assessment-tool-generator:@@PROJECT_VERSION@@ -f docker/Dockerfile --build-arg http_proxy= --build-arg https_proxy= .
-docker run -it --rm -v ${PWD}/docker:/exporter --env-file ./docker/.env -e mvn_flags=-DexcludedGroups=com.sap.psr.vulas.shared.categories.Slow vulnerability-assessment-tool-generator:@@PROJECT_VERSION@@
-```
-
-!!! warning "Build error"
-
-	If the command above fails, add `-DreuseForks=False` flag to `mvn_flags`. As shown in the example below.
-
-    ```sh
-    docker run -it --rm -v ${PWD}/docker:/exporter --env-file ./docker/.env -e mvn_flags='-DexcludedGroups=com.sap.psr.vulas.shared.categories.Slow -DreuseForks=False' vulnerability-assessment-tool-generator:@@PROJECT_VERSION@@
-    ```
-
-In case you are running behind a proxy you need to configure it in the `--build-arg` arguments.
-
-As a result, the folders `docker/<component-name>` will contain compiled JARs (or WARs, depending on the component). The folder `docker/client-tools` will be populated with the JARs for client side tools (CLI, plugins, patchanalyzer).
-
-Finally, you may want to make all artifacts available to the developers of your organization (e.g., through an internal Nexus or other artifact distribution system).
+> In `docker/.env` you must configure at least `POSTGRES_USER=`, you should also configure the `HAPROXY`'s user and password as well as the credentials to access the bugs' frontend
 
 ### Run
 

--- a/docs/public/content/admin/tutorials/registry.md
+++ b/docs/public/content/admin/tutorials/registry.md
@@ -1,13 +1,11 @@
 # Push Docker images on a registry
 
-!!! warning "Official @@PROJECT_NAME@@ images"
-    @@PROJECT_NAME@@ does **not** officially publish Docker images on any public registry such as Docker Hub or Quay.io. The provided Bash script is meant to push images to **local** Docker repositories running within your organization.
-
 ## Pre-requisites
 
 - git
 - bash
 - docker
+- docker-compose
 
 ## Generate @@PROJECT_NAME@@ images
 
@@ -33,10 +31,11 @@ To use the script you will need:
 - a username
 - @@PROJECT_NAME@@ used version
 
-Invoke the script with the following positional arguments. The script will authenticate yourself on the registry, tag your images and push them.
+Invoke the script with the following positional arguments.
 
 ```sh
-bash push-images.sh [registry] [username] [vulnerability-assessment-tool-version]
+docker login [registry]
+bash push-images.sh -r [registry] -u [username] -v [vulnerability-assessment-tool-version]
 ```
 
 ## Pulling the images from a repository

--- a/docs/public/content/admin/tutorials/registry.md
+++ b/docs/public/content/admin/tutorials/registry.md
@@ -9,7 +9,7 @@
 
 ## Generate @@PROJECT_NAME@@ images
 
-In order to generate the Docker images to upload to a local registry, you should generate @@PROJECT_NAME@@'s Java archives. This can be done following the first part of the [Deploy on Docker tutorial](../docker/#build-docker-images). To briefly summarize you should build and run an image which will populate your local directories with the @@PROJECT_NAME@@ JARs and WARs. In the end of this preliminary step you should have your images locally, this can be tested with the command `docker images | grep vulnerability-assessment-tool`.
+In order to generate the Docker images to upload to a local registry, you should generate @@PROJECT_NAME@@'s Java archives. This can be done following [Build JAVA archives/Docker images](../build/) tutorial. To briefly summarize you should build and run an image which will populate your local directories with the @@PROJECT_NAME@@ JARs and WARs. In the end of this preliminary step you should have your images locally, this can be tested with the command `docker images | grep vulnerability-assessment-tool`.
 
 ```sh
 # sample output for `docker images` command


### PR DESCRIPTION
<!-- Describe your contribution -->
Since we now have our images on Docker Hub. It's easier for users to deploy `vulnerability-assessment-tool`, they don't need anymore to build the images locally, they just pull the official ones.

We now thus have two `docker-compose` files. One that uses the pushed images and one that builds locally.

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [x] Documentation