### PR TITLE
fix(repo-client): GitClient splits rev:branch

### DIFF
--- a/repo-client/src/main/java/com/sap/psr/vulas/git/GitClient.java
+++ b/repo-client/src/main/java/com/sap/psr/vulas/git/GitClient.java
@@ -381,9 +381,10 @@ public class GitClient implements IVCSClient {
 		final StopWatch sw = new StopWatch("Get file changes for revision [" + _rev.substring( 0, (_rev.length()>8)?8:_rev.length() ) + "]").start();
 
 		String branch = "";
-		if(_rev.contains(":")){
-			branch = _rev.substring(_rev.indexOf(":")+1, _rev.length())+":";
-			_rev= _rev.substring(0,_rev.indexOf(":")-1);
+		if(_rev.contains(":")) {
+			String [] rev_branch = _rev.split(":");
+			_rev = rev_branch[0];
+			branch = rev_branch[1];
 		}
 
 		// TODO: use this.repository instead


### PR DESCRIPTION
Use `_rev.split(":")` to splits String `_rev` in `getFileChanges` method when it contains revision hash and branch tag.
This change will fix the bug that `GitClient` does not create a new directory with the full revision hash (40 characters).

<!-- Describe your contribution -->

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [x] Tests
- [ ] Documentation