### PR TITLE
fix dependency structure

### DIFF
--- a/lang-java/src/main/java/com/sap/psr/vulas/java/JarAnalyzer.java
+++ b/lang-java/src/main/java/com/sap/psr/vulas/java/JarAnalyzer.java
@@ -575,7 +575,8 @@ public class JarAnalyzer implements Callable<FileAnalyzer>, JarEntryWriter, File
 	/** {@inheritDoc} */
 	@Override
 	public boolean equals(Object obj){
-		return obj instanceof JarAnalyzer && this.getSHA1().equals(((JarAnalyzer)obj).getSHA1());
+		//We need to distinguish Jars with same digest but different path to be able to link parents to their digest. However the relativePath should be used once we start using it.
+		return obj instanceof JarAnalyzer && this.getSHA1().equals(((JarAnalyzer)obj).getSHA1()) && this.getPath().toString().equals(((JarAnalyzer)obj).getPath().toString());
 	}
 
 	/** {@inheritDoc} */

--- a/lang/src/main/java/com/sap/psr/vulas/goals/BomGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/BomGoal.java
@@ -76,8 +76,10 @@ public class BomGoal extends AbstractAppGoal {
 		final MaliciousnessAnalyzerLoop loop = new MaliciousnessAnalyzerLoop();
 		
 		// Get a clean set of dependencies
-		final Set<Dependency> no_dupl_deps = DependencyUtil.removeDuplicateLibraryDependencies(a.getDependencies());
-		a.setDependencies(no_dupl_deps);
+		// The removal of dependencies on the same digest is not done here any longer to be able to set parents on the dependencies that will not be removed
+		// Once we add the usage of relativePath to distinguish among dependencies, the removal can be done at this step again.
+	//	final Set<Dependency> no_dupl_deps = DependencyUtil.removeDuplicateLibraryDependencies(a.getDependencies());
+	//	a.setDependencies(no_dupl_deps);
 
 		// Upload libraries and binaries (if requested)
 		if(a.getDependencies()!=null) {

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DependencyUtil.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/util/DependencyUtil.java
@@ -67,10 +67,13 @@ public class DependencyUtil {
 	public static Dependency getDependency(Set<Dependency> _deps, Dependency _dep) {
 		for(Dependency d: _deps) {
 			 if(d.getLib().equals(_dep.getLib()) &&
-					( (d.getParent() == null && _dep.getParent()==null) ||
-							d.getParent().equalLibParentRelPath(_dep.getParent())) &&
-					( (d.getRelativePath() == null && _dep.getRelativePath()==null) ||
-							d.getRelativePath().equals(_dep.getRelativePath()))) {
+					( (d.getParent() == null && _dep.getParent()==null) || (d.getParent() != null && _dep.getParent()!=null &&
+							d.getParent().equalLibParentRelPath(_dep.getParent()))) &&
+					( (d.getRelativePath() == null && _dep.getRelativePath()==null) || (d.getRelativePath() != null && _dep.getRelativePath()!=null &&
+							d.getRelativePath().equals(_dep.getRelativePath()))) 
+					//&&	( (d.getPath() == null && _dep.getPath()==null) || (d.getPath() != null && _dep.getPath()!=null &&
+					//d.getPath().equals(_dep.getPath())))
+					 ) {
 				return d;
 			}
 		}


### PR DESCRIPTION
The dependency list of an application (including parents information) must conform two main rules:
- parents must be included in the main set
- each dependency in the main set must occur only once.

Currently, the elements which differentiate dependency are : digest, parent, and relativePath.

The existing client is not populating the relativePath but only the path, as a result it may happen that the backend return HTTP 500 in case two dependencies in the main set have same digest and parent null (even if the path differs as we currently use the relativePath to differentiate).

Alternatives to be discussed:
- add use of relative path in the client
- remove dependency with same digest, parent and relativePath before upload (we loose some details but the upload will succeed)
- use the path to discriminate from the backend side (though the path is system-specific, this is usually used just in the scope of a single scan)