### PR TITLE
Modified pom.xml of rest-backend and rest-lib-utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ matrix:
     - rm -rf $HOME/.m2/repository/com/sap/research/security/vulas/
     install:
     - echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'
-    script: mvn -e -B -P gradle -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
+    script: mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
   - name: OpenJDK8 - Create Maven artifacts for JavaDoc and sources
     language: java
     jdk: openjdk8
     install:
     - echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'
-    script: mvn -e -B -P gradle,javadoc -DskipTests --settings .travis/settings.xml clean package
+    script: mvn -e -B -P gradle,javadoc -Dspring.standalone -DskipTests --settings .travis/settings.xml clean package
   - name: Docker - Build the Modules' Jars, Run all Java tests, Create vital containers, Check if they stay alive for more than 20 seconds
     language: bash
     sudo: required

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -23,7 +23,6 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<!-- Specify as system property (-D) -->
 		<snapshots.repo></snapshots.repo>
-		<milestones.repo></milestones.repo>
 		<releases.repo></releases.repo>
 	</properties>
 
@@ -40,8 +39,8 @@
 		</snapshotRepository>
 		<repository>
 			<id>build.releases.repo</id>
-			<name>Internal Releases</name>
-			<url>${milestones.repo}</url>
+			<name>releases</name>
+			<url>${releases.repo}</url>
 		</repository>
 		<site>
 			<id>vulas.website</id>
@@ -179,6 +178,14 @@
 			<artifactId>flyway-core</artifactId>
 			<version>5.0.7</version>
 		</dependency>
+		
+		<!-- To prevent javadoc error "class file for javax.interceptor.InterceptorBinding not found" -->
+		<dependency>
+		    <groupId>javax.interceptor</groupId>
+		    <artifactId>javax.interceptor-api</artifactId>
+		    <version>1.2.2</version>
+		</dependency>
+		
 	</dependencies>
 
 	<dependencyManagement>
@@ -242,6 +249,9 @@
 		<profile>
 			<id>standalone</id>
 			<activation>
+				<property>
+			    	<name>spring.standalone</name>
+			    </property>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
@@ -306,6 +316,78 @@
 							<path>/backend</path>
 							<warFile>${project.build.directory}/${project.build.finalName}.war</warFile>
 							<update>true</update>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
+		<profile>
+			<id>javadoc</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.2.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!--  Run the following to fix all JavaDoc: "mvn -DdefaultAuthor=SAP -X -DfixTags=param,return,throws -P gradle clean compile org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:fix"
+					The tag 'links' results in an exception in module lang-java.-->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>3.1.1</version>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.5</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!-- Deploy to the Central Repository according to https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release. -->
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId> 
+						<version>1.6.8</version>
+						<extensions>true</extensions>
+						<configuration>
+							<serverId>ossrh</serverId> 
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+							<autoReleaseAfterClose>true</autoReleaseAfterClose> 
 						</configuration>
 					</plugin>
 				</plugins>

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/cve/CveReader2.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/cve/CveReader2.java
@@ -26,7 +26,7 @@ import com.sap.psr.vulas.shared.util.VulasConfiguration;
 import net.minidev.json.JSONArray;
 
 /**
- * Reads {@link CVE} information from a service configured with {@link #CVE_SERVICE_URL}.
+ * Reads {@link Cve} information from a service configured with {@link #CVE_SERVICE_URL}.
  */
 public class CveReader2 implements ObjectFetcher<String, Cve> {
 	

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -28,7 +28,6 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<!-- Specify as system property (-D) -->
 		<snapshots.repo></snapshots.repo>
-		<milestones.repo></milestones.repo>
 		<releases.repo></releases.repo>
 	</properties>
 
@@ -43,11 +42,11 @@
 			<id>ossrh</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
-        <repository>
-            <id>build.releases.repo</id>
-            <name>Internal Releases</name>
-            <url>${milestones.repo}</url>
-        </repository>
+		<repository>
+			<id>build.releases.repo</id>
+			<name>releases</name>
+			<url>${releases.repo}</url>
+		</repository>
         <site>
             <id>vulas.website</id>
             <name>Vulas Documentation</name>
@@ -252,6 +251,9 @@
 		<profile>
 			<id>standalone</id>
 			<activation>
+				<property>
+			    	<name>spring.standalone</name>
+			    </property>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
@@ -307,6 +309,79 @@
 				</plugins>
 			</build>
 		</profile>
+		
+		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
+		<profile>
+			<id>javadoc</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.2.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!--  Run the following to fix all JavaDoc: "mvn -DdefaultAuthor=SAP -X -DfixTags=param,return,throws -P gradle clean compile org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:fix"
+					The tag 'links' results in an exception in module lang-java.-->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>3.1.1</version>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.5</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!-- Deploy to the Central Repository according to https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release. -->
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId> 
+						<version>1.6.8</version>
+						<extensions>true</extensions>
+						<configuration>
+							<serverId>ossrh</serverId> 
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+							<autoReleaseAfterClose>true</autoReleaseAfterClose> 
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
 	</profiles>
 	<build>
 		<plugins>


### PR DESCRIPTION
Since the Maven modules `rest-backend` and `rest-lib-utils` do not inherit from root, the profiles to generate JavaDoc, PGP sign and release to Maven Central had to be copied into their respective `pom.xml`.

<!-- Describe your contribution -->

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [ ] Documentation