### PR TITLE
Add jib plugin to the maven settings.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ matrix:
     - provider: script
       skip_cleanup: true
       script: bash .travis/docker_hub_push_release.sh
-
+      on:
+        branch: master
+        condition: $TRAVIS_EVENT_TYPE = push
+        
   - name: OpenJDK8 - Create Maven artifacts for JavaDoc and sources
     language: java
     jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,12 @@ matrix:
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64
     - chmod +x .travis/skaffold
     - export JIB=true
+    - echo "
+<settings>
+  <pluginGroups>
+    <pluginGroup>com.google.cloud.tools</pluginGroup>
+  </pluginGroups>
+</settings>" > "$HOME/.m2/settings.xml"
     deploy:
     - provider: script
       skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
     - provider: script
       skip_cleanup: true
       script: bash .travis/docker_hub_push_release.sh
-      on:
-        all_branches: true
 
   - name: OpenJDK8 - Create Maven artifacts for JavaDoc and sources
     language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     script:
     - mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
     before_deploy:
+    - cp .travis/settings.xml $HOME/.m2/settings.xml
     - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64
     - chmod +x .travis/skaffold
-    - echo "<settings><pluginGroups><pluginGroup>com.google.cloud.tools</pluginGroup></pluginGroups></settings>" > $HOME/.m2/settings.xml
     - export JIB=true
     deploy:
     - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
     script:
     - mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
     before_deploy:
-    - cp .travis/settings.xml $HOME/.m2/settings.xml
     - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ matrix:
     - rm -rf $HOME/.m2/repository/com/sap/research/security/vulas/
     install:
     - echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'
-    script:
-    - mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
+    script: mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
     before_deploy:
     - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,26 @@ matrix:
     script:
     - mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
     before_deploy:
+    - cp .travis/settings.xml $HOME/.m2/settings.xml
     - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64
     - chmod +x .travis/skaffold
     - export JIB=true
-    - echo "<settings><pluginGroups><pluginGroup>com.google.cloud.tools</pluginGroup></pluginGroups></settings>" > "$HOME/.m2/settings.xml"
     deploy:
+    - provider: script
+      skip_cleanup: true
+      script: bash .travis/docker_hub_push_snapshot.sh
+      on:
+        branch: master
+        condition: $TRAVIS_EVENT_TYPE = push
     - provider: script
       skip_cleanup: true
       script: bash .travis/docker_hub_push_release.sh
       on:
-        branch: master
-        condition: $TRAVIS_EVENT_TYPE = push
-        
+        all_branches: true
+        condition: tag =~ /^[0-9]+\.[0-9]+\.[0-9]+(\..+)?$/
+
   - name: OpenJDK8 - Create Maven artifacts for JavaDoc and sources
     language: java
     jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
     - echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'
     script: mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
     before_deploy:
-    - ls -alh $HOME/.m2
-    - rm $HOME/.m2/settings.xml
     - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64
@@ -39,7 +37,7 @@ matrix:
     jdk: openjdk8
     install:
     - echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'
-    script: mvn -e -B -P gradle,javadoc -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
+    script: mvn -e -B -P gradle,javadoc -Dspring.standalone -DskipTests --settings .travis/settings.xml clean package
   - name: Docker - Build the Modules' Jars, Run all Java tests, Create vital containers, Check if they stay alive for more than 20 seconds
     language: bash
     sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     script:
     - mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
     before_deploy:
-    - cp .travis/settings.xml $HOME/.m2/settings.xml
     - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64
     - chmod +x .travis/skaffold
+    - echo "<settings><pluginGroups><pluginGroup>com.google.cloud.tools</pluginGroup></pluginGroups></settings>" > $HOME/.m2/settings.xml
     - export JIB=true
     deploy:
     - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     before_deploy:
     - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
-    - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
+    - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64
     - chmod +x .travis/skaffold
     - export JIB=true
     deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,7 @@ matrix:
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64
     - chmod +x .travis/skaffold
     - export JIB=true
-    - echo "
-<settings>
-  <pluginGroups>
-    <pluginGroup>com.google.cloud.tools</pluginGroup>
-  </pluginGroups>
-</settings>" > "$HOME/.m2/settings.xml"
+    - echo "<settings><pluginGroups><pluginGroup>com.google.cloud.tools</pluginGroup></pluginGroups></settings>" > "$HOME/.m2/settings.xml"
     deploy:
     - provider: script
       skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
       directories:
       - "$HOME/.m2"
     before_cache:
+    - rm $HOME/.m2/settings.xml
     - rm -rf $HOME/.m2/repository/com/sap/research/security/vulas/
     install:
     - echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,13 @@ matrix:
       directories:
       - "$HOME/.m2"
     before_cache:
-    - rm $HOME/.m2/settings.xml
     - rm -rf $HOME/.m2/repository/com/sap/research/security/vulas/
     install:
     - echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'
     script: mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
     before_deploy:
+    - ls -alh $HOME/.m2
+    - rm $HOME/.m2/settings.xml
     - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/v0.40.0/skaffold-linux-amd64
@@ -38,7 +39,7 @@ matrix:
     jdk: openjdk8
     install:
     - echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'
-    script: mvn -e -B -P gradle,javadoc -Dspring.standalone -DskipTests --settings .travis/settings.xml clean package
+    script: mvn -e -B -P gradle,javadoc -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
   - name: Docker - Build the Modules' Jars, Run all Java tests, Create vital containers, Check if they stay alive for more than 20 seconds
     language: bash
     sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     script:
     - mvn -e -B -P gradle -Dspring.standalone -Dit.test='!IT01_PatchAnalyzerIT, IT*, *IT, *ITCase' -DfailIfNoTests=false --settings .travis/settings.xml clean install
     before_deploy:
-    - set -a; source docker/.env; set +a;
+    - set -a; source .travis/.env; set +a;
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
     - chmod +x .travis/skaffold

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,11 @@ matrix:
     deploy:
     - provider: script
       skip_cleanup: true
+      on:
+        all_branches: true
       script:
+      - ls -alh
+      - env
       - echo "$DOCKER_HUB_NARAMSIM_PASSWORD" | docker login -u "$DOCKER_HUB_NARAMSIM_USERNAME" --password-stdin
       - ./.travis/skaffold build -f ./.travis/skaffold.yaml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,13 @@ matrix:
     - echo "VULAS_RELEASE=${VULAS_RELEASE}"
     - curl -Lo .travis/skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
     - chmod +x .travis/skaffold
+    - export JIB=true
     deploy:
     - provider: script
       skip_cleanup: true
+      script: bash .travis/docker_hub_push_release.sh
       on:
         all_branches: true
-      script:
-      - ls -alh
-      - env
-      - echo "$DOCKER_HUB_NARAMSIM_PASSWORD" | docker login -u "$DOCKER_HUB_NARAMSIM_USERNAME" --password-stdin
-      - ./.travis/skaffold build -f ./.travis/skaffold.yaml
 
   - name: OpenJDK8 - Create Maven artifacts for JavaDoc and sources
     language: java

--- a/.travis/docker_hub_push_release.sh
+++ b/.travis/docker_hub_push_release.sh
@@ -2,7 +2,7 @@
 # Should be run from repository's root
 # Usage: bash .travis/docker_hub_push_releases.sh
 
-if [ "$VULAS_RELEASE" == "$TRAVIS_TAG" ]; then
+if [ "$VULAS_RELEASE" != "$TRAVIS_TAG" ]; then
   echo '[-] VULAS_RELEASE and Git tag mismatch'
   echo "    VULAS_RELEASE: ${VULAS_RELEASE}"
   echo "    Git tag: ${TRAVIS_TAG}"

--- a/.travis/docker_hub_push_release.sh
+++ b/.travis/docker_hub_push_release.sh
@@ -2,12 +2,13 @@
 # Should be run from repository's root
 # Usage: bash .travis/docker_hub_push_releases.sh
 
-if [ "$VULAS_RELEASE" != "$TRAVIS_TAG" ]; then
-  echo '[-] VULAS_RELEASE and Git tag mismatch'
-  echo "    VULAS_RELEASE: ${VULAS_RELEASE}"
-  echo "    Git tag: ${TRAVIS_TAG}"
-  exit 1
-fi
+# 
+# if [ "$VULAS_RELEASE" != "$TRAVIS_TAG" ]; then
+#   echo '[-] VULAS_RELEASE and Git tag mismatch'
+#   echo "    VULAS_RELEASE: ${VULAS_RELEASE}"
+#   echo "    Git tag: ${TRAVIS_TAG}"
+#   exit 1
+# fi
 
 echo "$DOCKER_HUB_NARAMSIM_PASSWORD" | docker login -u "$DOCKER_HUB_NARAMSIM_USERNAME" --password-stdin
 if [ -z "$JIB" ]; then

--- a/.travis/docker_hub_push_release.sh
+++ b/.travis/docker_hub_push_release.sh
@@ -3,11 +3,15 @@
 # Usage: bash .travis/docker_hub_push_releases.sh
 
 if [ "$VULAS_RELEASE" == "$TRAVIS_TAG" ]; then
-    echo "$DOCKER_HUB_NARAMSIM_PASSWORD" | docker login -u "$DOCKER_HUB_NARAMSIM_USERNAME" --password-stdin
-    (cd docker && bash push-images.sh -r docker.io -p vulas -v "$TRAVIS_TAG")
+  echo '[-] VULAS_RELEASE and Git tag mismatch'
+  echo "    VULAS_RELEASE: ${VULAS_RELEASE}"
+  echo "    Git tag: ${TRAVIS_TAG}"
+  exit 1
+fi
+
+echo "$DOCKER_HUB_NARAMSIM_PASSWORD" | docker login -u "$DOCKER_HUB_NARAMSIM_USERNAME" --password-stdin
+if [ -z "$JIB" ]; then
+  (cd docker && bash push-images.sh -r docker.io -p vulas -v "$TRAVIS_TAG")
 else
-    echo '[-] VULAS_RELEASE and Git tag mismatch'
-    echo "    VULAS_RELEASE: ${VULAS_RELEASE}"
-    echo "    Git tag: ${TRAVIS_TAG}"
-    exit 1
+  ./.travis/skaffold build -f ./.travis/skaffold.yaml
 fi

--- a/.travis/docker_hub_push_release.sh
+++ b/.travis/docker_hub_push_release.sh
@@ -2,13 +2,13 @@
 # Should be run from repository's root
 # Usage: bash .travis/docker_hub_push_releases.sh
 
-#
-# if [ "$VULAS_RELEASE" != "$TRAVIS_TAG" ]; then
-#   echo '[-] VULAS_RELEASE and Git tag mismatch'
-#   echo "    VULAS_RELEASE: ${VULAS_RELEASE}"
-#   echo "    Git tag: ${TRAVIS_TAG}"
-#   exit 1
-# fi
+
+if [ "$VULAS_RELEASE" != "$TRAVIS_TAG" ]; then
+  echo '[-] VULAS_RELEASE and Git tag mismatch'
+  echo "    VULAS_RELEASE: ${VULAS_RELEASE}"
+  echo "    Git tag: ${TRAVIS_TAG}"
+  exit 1
+fi
 
 echo "$DOCKER_HUB_NARAMSIM_PASSWORD" | docker login -u "$DOCKER_HUB_NARAMSIM_USERNAME" --password-stdin
 if [ -z "$JIB" ]; then

--- a/.travis/docker_hub_push_release.sh
+++ b/.travis/docker_hub_push_release.sh
@@ -2,7 +2,7 @@
 # Should be run from repository's root
 # Usage: bash .travis/docker_hub_push_releases.sh
 
-# 
+#
 # if [ "$VULAS_RELEASE" != "$TRAVIS_TAG" ]; then
 #   echo '[-] VULAS_RELEASE and Git tag mismatch'
 #   echo "    VULAS_RELEASE: ${VULAS_RELEASE}"

--- a/.travis/docker_hub_push_snapshot.sh
+++ b/.travis/docker_hub_push_snapshot.sh
@@ -4,7 +4,11 @@
 
 if [[ $VULAS_RELEASE =~ ^([0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT)$ ]]; then
     echo "$DOCKER_HUB_NARAMSIM_PASSWORD" | docker login -u "$DOCKER_HUB_NARAMSIM_USERNAME" --password-stdin
-    (cd docker && bash push-images.sh -r docker.io -p vulas -v "${VULAS_RELEASE}")
+    if [ -z "$JIB" ]; then
+      (cd docker && bash push-images.sh -r docker.io -p vulas -v "${VULAS_RELEASE}")
+    else
+      ./.travis/skaffold build -f ./.travis/skaffold.yaml
+    fi
 else
     echo '[!] Refusing to push non-snapshot version'
     echo "    VULAS_RELEASE: $VULAS_RELEASE"

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -80,6 +80,7 @@ under the License.
      | Specifies a further group identifier to use for plugin lookup.
     <pluginGroup>com.your.plugins</pluginGroup>
     -->
+    <pluginGroup>com.google.cloud.tools</pluginGroup>
   </pluginGroups>
 
   <!-- proxies

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -80,7 +80,6 @@ under the License.
      | Specifies a further group identifier to use for plugin lookup.
     <pluginGroup>com.your.plugins</pluginGroup>
     -->
-    <pluginGroup>com.google.cloud.tools</pluginGroup>
   </pluginGroups>
 
   <!-- proxies

--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
 			<plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>1.6.1</version>
+        <version>1.7.0</version>
       </plugin>
 
 			<!-- Show whether there are newer versions available, run fully-qualified
@@ -479,10 +479,10 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>com.google.cloud.tools</groupId>
-					<artifactId>jib-maven-plugin</artifactId>
-					<version>1.6.1</version>
-				</plugin>
+	        <groupId>com.google.cloud.tools</groupId>
+	        <artifactId>jib-maven-plugin</artifactId>
+	        <version>1.7.0</version>
+	      </plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<!-- Repos to which Vulas artifacts will be deployed, must be provided 
+		<!-- Repos to which Vulas artifacts will be deployed, must be provided
 			as system property (-D) (no defaults) -->
 		<snapshots.repo></snapshots.repo>
 		<releases.repo></releases.repo>
 
-		<!-- Repos used for resolving dependencies, specify as system property 
+		<!-- Repos used for resolving dependencies, specify as system property
 			(-D) to change the defaults -->
 		<gradle.repo>https://maven.google.com/</gradle.repo>
 	</properties>
@@ -155,7 +155,7 @@
 				</plugins>
 			</build>
 		</profile>
-		
+
 		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
 		<profile>
 			<id>release</id>
@@ -178,13 +178,13 @@
 					<!-- Deploy to the Central Repository according to https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release. -->
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId> 
+						<artifactId>nexus-staging-maven-plugin</artifactId>
 						<version>1.6.8</version>
 						<extensions>true</extensions>
 						<configuration>
-							<serverId>ossrh</serverId> 
+							<serverId>ossrh</serverId>
 							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose> 
+							<autoReleaseAfterClose>true</autoReleaseAfterClose>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -357,8 +357,13 @@
 
 	<build>
 		<plugins>
+			<plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>1.6.1</version>
+      </plugin>
 
-			<!-- Show whether there are newer versions available, run fully-qualified 
+			<!-- Show whether there are newer versions available, run fully-qualified
 				with 'mvn -DallowMajorUpdates=false -DprocessDependencyManagement=false org.codehaus.mojo:versions-maven-plugin:2.5:display-dependency-updates' -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -381,7 +386,7 @@
 				</configuration>
 			</plugin>
 
-			<!-- Successor of Findbugs, run fully-qualified with 'mvn -Dspotbugs.excludeFilterFile=findbugs-exclude.xml 
+			<!-- Successor of Findbugs, run fully-qualified with 'mvn -Dspotbugs.excludeFilterFile=findbugs-exclude.xml
 				-Dspotbugs.failOnError=false -P soot,gradle com.github.spotbugs:spotbugs-maven-plugin:3.1.11:check' -->
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
@@ -536,7 +541,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
 				<version>3.7.1</version>
-				<!--configuration> <outputDirectory>${project.basedir}/docs/site</outputDirectory> 
+				<!--configuration> <outputDirectory>${project.basedir}/docs/site</outputDirectory>
 					</configuration -->
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,11 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>com.google.cloud.tools</groupId>
+					<artifactId>jib-maven-plugin</artifactId>
+					<version>1.6.1</version>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
 					<version>3.7.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,7 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <version>1.7.0</version>
+				<extensions>true</extensions>
       </plugin>
 
 			<!-- Show whether there are newer versions available, run fully-qualified

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -400,6 +400,7 @@
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
 				<version>1.7.0</version>
+				<extensions>true</extensions>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/rest-backend/pom.xml
+++ b/rest-backend/pom.xml
@@ -178,14 +178,14 @@
 			<artifactId>flyway-core</artifactId>
 			<version>5.0.7</version>
 		</dependency>
-		
+
 		<!-- To prevent javadoc error "class file for javax.interceptor.InterceptorBinding not found" -->
 		<dependency>
 		    <groupId>javax.interceptor</groupId>
 		    <artifactId>javax.interceptor-api</artifactId>
 		    <version>1.2.2</version>
 		</dependency>
-		
+
 	</dependencies>
 
 	<dependencyManagement>
@@ -208,7 +208,7 @@
 				<version>2.9.10</version>
 			</dependency>
 
-			<!-- Fix Spring Boot's dependency on vulnerable dom4j 1.6.1, inherited 
+			<!-- Fix Spring Boot's dependency on vulnerable dom4j 1.6.1, inherited
 				from hibernate-core and hibernate-entitymanager 5.0.12.Final (org.springframework.boot:spring-boot-dependencies:1.5.19.RELEASE) -->
 			<dependency>
 				<groupId>org.hibernate</groupId>
@@ -232,7 +232,7 @@
 				<artifactId>logback-core</artifactId>
 				<version>1.2.3</version>
 			</dependency>
-			
+
 			<!--  Fix dependency on vulnerable commons-beanutils 1.9.3 -->
 			<dependency>
 				<groupId>commons-beanutils</groupId>
@@ -266,7 +266,7 @@
 				<dependency>
 					<groupId>com.h2database</groupId>
 					<artifactId>h2</artifactId>
-					<version>1.4.199</version><!-- Fix Spring Boot's dependency on vulnerable 
+					<version>1.4.199</version><!-- Fix Spring Boot's dependency on vulnerable
 						h2 1.4.197 (org.springframework.boot:spring-boot-dependencies:1.5.19.RELEASE) -->
 				</dependency>
 				<dependency>
@@ -304,8 +304,8 @@
 			</dependencies>
 			<build>
 				<plugins>
-					<!-- Maintain admin credentials for vulas-tomcat-server @ {host:port} 
-						in settings.xml. Build WAR Run "mvn -Dmaven.tomcat.url={host:port}/manager/text 
+					<!-- Maintain admin credentials for vulas-tomcat-server @ {host:port}
+						in settings.xml. Build WAR Run "mvn -Dmaven.tomcat.url={host:port}/manager/text
 						-P container package tomcat7:deploy-only". Point browser to {host:port}/apps -->
 					<plugin>
 						<groupId>org.apache.tomcat.maven</groupId>
@@ -321,7 +321,7 @@
 				</plugins>
 			</build>
 		</profile>
-		
+
 		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
 		<profile>
 			<id>javadoc</id>
@@ -358,7 +358,7 @@
 				</plugins>
 			</build>
 		</profile>
-		
+
 		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
 		<profile>
 			<id>release</id>
@@ -381,13 +381,13 @@
 					<!-- Deploy to the Central Repository according to https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release. -->
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId> 
+						<artifactId>nexus-staging-maven-plugin</artifactId>
 						<version>1.6.8</version>
 						<extensions>true</extensions>
 						<configuration>
-							<serverId>ossrh</serverId> 
+							<serverId>ossrh</serverId>
 							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose> 
+							<autoReleaseAfterClose>true</autoReleaseAfterClose>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -396,6 +396,11 @@
 	</profiles>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>1.7.0</version>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -430,16 +435,16 @@
 	</build>
 
 	<!-- Run with 'mvn clean site site:deploy' -->
-	<!--reporting> <plugins> <plugin> <groupId>org.apache.maven.plugins</groupId> 
-		<artifactId>maven-project-info-reports-plugin</artifactId> <version>2.9</version> 
-		</plugin> <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-javadoc-plugin</artifactId> 
-		<version>3.0.0</version> <configuration> <failOnError>false</failOnError> 
-		<noindex>false</noindex> <links> <link>http://java.sun.com/j2se/1.5.0/docs/api</link> 
-		</links> </configuration> <reportSets> <reportSet> <id>aggregate</id> <configuration> 
-		</configuration> <reports> <report>aggregate</report> </reports> </reportSet> 
-		</reportSets> </plugin> <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>findbugs-maven-plugin</artifactId> 
-		<version>3.0.5</version> </plugin> <plugin> <groupId>org.apache.maven.plugins</groupId> 
-		<artifactId>maven-checkstyle-plugin</artifactId> <version>3.0.0</version> 
-		<reportSets> <reportSet> <reports> <report>checkstyle</report> </reports> 
+	<!--reporting> <plugins> <plugin> <groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-project-info-reports-plugin</artifactId> <version>2.9</version>
+		</plugin> <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-javadoc-plugin</artifactId>
+		<version>3.0.0</version> <configuration> <failOnError>false</failOnError>
+		<noindex>false</noindex> <links> <link>http://java.sun.com/j2se/1.5.0/docs/api</link>
+		</links> </configuration> <reportSets> <reportSet> <id>aggregate</id> <configuration>
+		</configuration> <reports> <report>aggregate</report> </reports> </reportSet>
+		</reportSets> </plugin> <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>findbugs-maven-plugin</artifactId>
+		<version>3.0.5</version> </plugin> <plugin> <groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-checkstyle-plugin</artifactId> <version>3.0.0</version>
+		<reportSets> <reportSet> <reports> <report>checkstyle</report> </reports>
 		</reportSet> </reportSets> </plugin> </plugins> </reporting -->
 </project>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -72,7 +72,7 @@
 			<artifactId>lang-python</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<!-- Spring -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -103,7 +103,7 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.6</version>
 		</dependency>
-		
+
 		<!-- Swagger core dependencies -->
 		<dependency>
 			<groupId>io.swagger</groupId>
@@ -162,7 +162,7 @@
 			<version>1.2.1-beta5</version>
 		</dependency>
 
-		<!-- The following are the dependencies of dependency-finder They have 
+		<!-- The following are the dependencies of dependency-finder They have
 			been pasted here from the dependency-finder pom.xml -->
 		<dependency>
 			<groupId>oro</groupId>
@@ -202,12 +202,12 @@
 			<scope>system</scope>
 			<systemPath>${java.home}/../lib/tools.jar</systemPath>
 		</dependency>
-		
+
 	</dependencies>
-	
+
 	<dependencyManagement>
 		<dependencies>
-		
+
 			<!-- Fix Spring Boot's dependency on vulnerable Jackson releases (org.springframework.boot:spring-boot-dependencies:1.5.19.RELEASE) -->
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
@@ -224,7 +224,7 @@
 				<artifactId>jackson-annotations</artifactId>
 				<version>2.9.10</version>
 			</dependency>
-			
+
 			<!-- Fix Spring Boot's dependency on vulnerable logback 1.1.11 (org.springframework.boot:spring-boot-dependencies:1.5.19.RELEASE) -->
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
@@ -236,14 +236,14 @@
 				<artifactId>logback-core</artifactId>
 				<version>1.2.3</version>
 			</dependency>
-			
+
 			<!--  Fix dependency on vulnerable commons-beanutils 1.9.3 -->
 			<dependency>
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
 				<version>1.9.4</version>
 			</dependency>
-			
+
 		</dependencies>
 	</dependencyManagement>
 
@@ -309,7 +309,7 @@
 				</plugins>
 			</build>
 		</profile>
-		
+
 		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
 		<profile>
 			<id>javadoc</id>
@@ -346,7 +346,7 @@
 				</plugins>
 			</build>
 		</profile>
-		
+
 		<!-- Activate when deploying to the Central Repo. Also see https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
 		<profile>
 			<id>release</id>
@@ -369,22 +369,27 @@
 					<!-- Deploy to the Central Repository according to https://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release. -->
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId> 
+						<artifactId>nexus-staging-maven-plugin</artifactId>
 						<version>1.6.8</version>
 						<extensions>true</extensions>
 						<configuration>
-							<serverId>ossrh</serverId> 
+							<serverId>ossrh</serverId>
 							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose> 
+							<autoReleaseAfterClose>true</autoReleaseAfterClose>
 						</configuration>
 					</plugin>
 				</plugins>
 			</build>
 		</profile>
-		
+
 	</profiles>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>1.7.0</version>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/rest-lib-utils/pom.xml
+++ b/rest-lib-utils/pom.xml
@@ -389,6 +389,7 @@
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
 				<version>1.7.0</version>
+				<extensions>true</extensions>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
<!-- Describe your contribution -->
This fixes the issue on the master branch with skaffold being unable to find `jib` prefix when building the jib container images by adding a pluginGroup to the settings.xml in the .m2 folder. Skaffold successfully builds images (the push procedure still needs to be tested using the official credentials)
<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [x] Tests
- [ ] Documentation