### PR TITLE
Throw exception and stop report generation if vulns cannot be downloaded

### DIFF
--- a/lang/src/main/java/com/sap/psr/vulas/goals/ReportGoal.java
+++ b/lang/src/main/java/com/sap/psr/vulas/goals/ReportGoal.java
@@ -1,6 +1,5 @@
 package com.sap.psr.vulas.goals;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -67,8 +66,8 @@ public class ReportGoal extends AbstractAppGoal {
 		// Fetch the vulns
 		try {
 			report.fetchAppVulnerabilities();
-		} catch (IOException e) {
-			throw new GoalExecutionException("Error fetching vulnerabilities from the backend: " + e.getMessage(), e);
+		} catch (Exception e) {
+			throw new GoalExecutionException("Error fetching vulnerabilities: " + e.getMessage(), e);
 		}
 
 		// Loop over vulnerabilities

--- a/lang/src/main/java/com/sap/psr/vulas/report/Report.java
+++ b/lang/src/main/java/com/sap/psr/vulas/report/Report.java
@@ -242,7 +242,7 @@ public class Report {
 	}
 	
 	/**
-	 * Downloads vulnerable dependencies for all {@link Application}s in member varaiable {@link #modules}.
+	 * Downloads vulnerable dependencies for all {@link Application}s in member variable {@link #modules}.
 	 * 
 	 * The member variable {@link #modules} only contains multiple {@link Application}s if the report is created through the Maven plugin and
 	 * the respective Maven project (for which the report goal is executed) is a multi-module aggregator project. If both conditions are met,


### PR DESCRIPTION
<!-- Describe your contribution -->
This fix improves the error handling of the report goal. When vulnerable dependencies cannot be downloaded, the report creation aborts.

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [x] Documentation