### PR TITLE
Removed commons-beanutils from shared

### DIFF
--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -49,10 +49,6 @@
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
<!-- Describe your contribution -->
Remove the direct dependency of module `shared` on `commons-beanutils`.

<!-- Check if you tested/documented your contribution -->

#### `TODO`s

- [ ] Tests
- [ ] Documentation