### PR TITLE
GCP integration fix

### DIFF
--- a/kubernetes/helm/utils/go.sum
+++ b/kubernetes/helm/utils/go.sum
@@ -94,6 +94,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/kubernetes/helm/utils/internal/load/load.go
+++ b/kubernetes/helm/utils/internal/load/load.go
@@ -216,7 +216,7 @@ func createPod(podClient corev1.PodInterface, chunkID int, bug CVE, context Cont
 	}
 
 	if !context.DryRun {
-		pod.Spec.Containers[0].Args = append(pod.Spec.Containers[0].Args, " -u")
+		pod.Spec.Containers[0].Args = append(pod.Spec.Containers[0].Args, "-u")
 	}
 
 	if context.Skip {

--- a/kubernetes/helm/utils/pkg/connect/client.go
+++ b/kubernetes/helm/utils/pkg/connect/client.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 )


### PR DESCRIPTION
This commit allows for clients to use the `vulas-utils` utility for managing their kubernetes cluster on any provider (GCP, AWS, Azure etc...).

#### `TODO`s

- [x] Tests
- [x] Documentation