### PR TITLE
Check that export item belongs to the tenant in question, fail if not

### DIFF
--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Space.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Space.java
@@ -362,7 +362,7 @@ public class Space {
 	/** {@inheritDoc} */
 	@Override
 	public String toString() {
-		return "space [token=" + spaceToken + ", name=" + spaceName + ", isTransient=" + this.isTransient() + "]";
+		return "[token=" + spaceToken + ", name=" + spaceName + ", isTransient=" + this.isTransient() + "]";
 	}
 	
 	/**

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Tenant.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/model/Tenant.java
@@ -135,6 +135,7 @@ public class Tenant {
 	 * @param spaces a {@link java.util.Collection} object.
 	 */
 	public void setSpaces(Collection<Space> spaces) { this.spaces = spaces; }
+	
 	/**
 	 * <p>addSpace.</p>
 	 *
@@ -144,6 +145,15 @@ public class Tenant {
 		if(this.getSpaces()==null)
 			this.spaces = new HashSet<Space>();
 		this.spaces.add(_space);
+	}
+	
+	/**
+	 * Returns true if the given space is part of this tenant, false otherwise.
+	 * 
+	 * @param _space a {@link com.sap.psr.vulas.backend.model.Space} object.
+	 */
+	public boolean hasSpace(Space _space) {
+		return this.getSpaces()!=null && this.getSpaces().contains(_space);
 	}
 	
 	/**
@@ -186,7 +196,7 @@ public class Tenant {
 	/** {@inheritDoc} */
 	@Override
 	public String toString() {
-		return "tenant [token=" + tenantToken + ", name=" + tenantName + "]";
+		return "[token=" + tenantToken + ", name=" + tenantName + "]";
 	}
 	
 	/**

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/HubIntegrationController.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/HubIntegrationController.java
@@ -297,6 +297,13 @@ public class HubIntegrationController {
 		try {
 			// Build from the simple string argument
 			final ExportItem item = ExportItem.fromString(itemId, separator, spaceRepository, appRepository);
+			
+			// Fail if the given space does not belong to the tenant in question
+			if(!t.hasSpace(item.getSpace())) {
+				log.error("Space " + item.getSpace() + " is not part of tenant " + t);
+				throw new IllegalArgumentException("Space " + item.getSpace() + " is not part of tenant " + t);
+			}
+			
 			final StopWatch sw = new StopWatch("Query vulnerable dependencies for item [" + itemId + "] (total)").start();
 
 			// The set to be returned


### PR DESCRIPTION
The endpoint `/hubIntegration/apps/{itemId:.+}/vulndeps` now checks whether the given export item (space or app) is indeed part of the tenant (the default one or the one specified with `X-Vulas-Tenant`). If not, the endpoint returns `400` (bad request).

#### `TODO`s

- [x] Tests
- [ ] Documentation