### PR TITLE
Urlencode construct signatures

### DIFF
--- a/frontend-apps/src/main/webapp/view/BugDetail.controller.js
+++ b/frontend-apps/src/main/webapp/view/BugDetail.controller.js
@@ -206,7 +206,7 @@ sap.ui.controller("view.BugDetail", {
 		var path = oEvent.getSource().getBindingContext().getPath();
 		var index = path.toString().split("/")[path.toString().split("/").length-1];
 		//var graphid = this.getView().byId('idBugDetailPage').getModel().getData().constructList[index].reachabilityGraph.id;
-		var change = this.getView().byId('idBugDetailPage').getModel().getData().constructList[index].constructChange.constructId.qname;
+		var change = encodeURIComponent(this.getView().byId('idBugDetailPage').getModel().getData().constructList[index].constructChange.constructId.qname);
 		var group = this.getView().byId('idBugDetailPage').getModel("app").getData().groupid;
 		console.log(path + " " + index + " " + change + " " + group + app.artifactid + " " + app.version + " "+ archiveId + " " + bugId);
 		const workspaceSlug = model.Config.getSpace()
@@ -276,10 +276,9 @@ sap.ui.controller("view.BugDetail", {
 			bugDetailPage.getModel("app").destroy();
 		}
 	},
+	
 	openWiki : function(evt){
-
 		model.Config.openWiki("user/manuals/frontend/#vulnerabilities-details");
-
 	},
 
 	handleNavBack : function() {

--- a/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/ApplicationController.java
+++ b/rest-backend/src/main/java/com/sap/psr/vulas/backend/rest/ApplicationController.java
@@ -2014,7 +2014,13 @@ public class ApplicationController {
 	 */
 	@RequestMapping(value = "/{mvnGroup:.+}/{artifact:.+}/{version:.+}/deps/{digest}/paths/{bugId}/{qname}", method = RequestMethod.GET, produces = {"application/json;charset=UTF-8"})
 	@JsonView(Views.Default.class)
-	public ResponseEntity<List<Path>> getVulndepConstructPaths(@PathVariable String mvnGroup, @PathVariable String artifact, @PathVariable String version, @PathVariable String digest, @PathVariable String bugId, @PathVariable String qname,
+	public ResponseEntity<List<Path>> getVulndepConstructPaths(
+			@PathVariable String mvnGroup,
+			@PathVariable String artifact,
+			@PathVariable String version,
+			@PathVariable String digest,
+			@PathVariable String bugId,
+			@PathVariable String qname,
 			@ApiIgnore @RequestHeader(value=Constants.HTTP_SPACE_HEADER, required=false) String space) {
 
 		Space s = null;
@@ -2024,6 +2030,7 @@ public class ApplicationController {
 			log.error("Error retrieving space: " + e);
 			return new ResponseEntity<List<Path>>(HttpStatus.NOT_FOUND);
 		}
+		
 		// Ensure that app exists
 		Application app = null;
 		try { app = ApplicationRepository.FILTER.findOne(this.appRepository.findByGAV(mvnGroup,artifact,version,s)); }


### PR DESCRIPTION
This fixes #230, which occurs when requesting the reachability graph for a construct whose signature contains special characters such as `[` or `]`.

- [ ] Tests
- [ ] Documentation