### PR TITLE
Improve documentation for data export

### DIFF
--- a/docs/public/content/user/manuals/analysis.md
+++ b/docs/public/content/user/manuals/analysis.md
@@ -609,7 +609,7 @@ Identified vulnerabilities including any information gathered during static and 
 #### Run as follows
 
 ```sh tab="CLI"
-java -Dvulas.core.appContext.group=<GROUP> -Dvulas.core.appContext.artifact=<ARTIFACT> -Dvulas.core.appContext.version=@@PROJECT_VERSION@@
+java -Dvulas.core.appContext.group=<GROUP> -Dvulas.core.appContext.artifact=<ARTIFACT> -Dvulas.core.appContext.version=<VERSION>
      -jar vulas-cli-jar-with-dependencies.jar -goal report
 ```
 

--- a/docs/public/content/user/manuals/setup.md
+++ b/docs/public/content/user/manuals/setup.md
@@ -56,11 +56,12 @@ Once this button is clicked, all the editable property-fields of the workspace a
 - update/change the data of your workspace as per your expectations.
 - Press the "Save" button to save your modifications, press the "close" button to revert your changes.
 
-### Workspace REST API
+### Export Analysis Results
 
-The REST API can be used to export findings in a machine-readable fashion. Calling HTTP GET on the following URL, for instance, returns all vulnerable dependencies of an aggregated workspace:
+The following REST API can be used to export findings (information about vulnerable dependencies) to JSON, either for entire workspaces or for single applications.
 
-`@@ADDRESS@@/backend/hubIntegration/apps/<workspace-name>%20(<workspace-token>)/vulndeps`
+For aggregated workspaces, call HTTP GET `@@ADDRESS@@/backend/hubIntegration/apps/<workspace-name>%20(<workspace-token>)/vulndeps`.
+For single applications, call HTTP GET `@@ADDRESS@@/backend/hubIntegration/apps/<workspace-name>%20(<workspace-token>)%20<group>:<artifact>:<version>/vulndeps`
 
 The API returns an array of JSON elements having the following data model:
 

--- a/docs/public/content/user/manuals/setup.md
+++ b/docs/public/content/user/manuals/setup.md
@@ -77,16 +77,6 @@ The API returns an array of JSON elements having the following data model:
 | count | Number of findings of type `type` in project | Always 1 |
 | snapshotDate | Date of most recent goal execution of the application (any goal) ||
 
-Query string parameter `ignoreUnassessed` 
-
-Determines whether un-assessed vulnerabilities are exported or ignored. Un-assessed vulns are those where the method signature(s) of a vulnerability appear in an archive, however, it is yet unclear whether the methods exist in the fixed or vulnerable version. Those findings are marked with an orange hourglass in the frontend.
-
-Possible values:
-
-- `all`: All un-assessed vulnerabilities will be ignored
-- `known`: Only un-assessed vulnerabilities in archives with a well-known digest will be ignored (those archives that exist in a public package repository such as Maven Central)
-- `off` (default): Never ignore
-
 ## Setup
 
 ### Maven


### PR DESCRIPTION
This change describes how to export findings for single applications. So far, the documentation only covered entire workspaces.

#### `TODO`s

- [ ] Tests
- [x] Documentation