### PR TITLE
Add latest tag to docker images

### DIFF
--- a/docker/push-images.sh
+++ b/docker/push-images.sh
@@ -67,7 +67,10 @@ fi
 
 
 for service in $SERVICES ; do
-    IMAGE=${REGISTRY}/${PROJECT}/vulnerability-assessment-tool-${service}:${VULAS_RELEASE}
-    docker tag vulnerability-assessment-tool-"${service}":"${VULAS_RELEASE}" "$IMAGE"
-    docker push "${IMAGE}"
+    IMAGE=${REGISTRY}/${PROJECT}/vulnerability-assessment-tool-${service}
+    docker tag vulnerability-assessment-tool-"${service}":"${VULAS_RELEASE}" "${IMAGE}:${VULAS_RELEASE}"
+    docker push "${IMAGE}:${VULAS_RELEASE}"
+
+    docker tag vulnerability-assessment-tool-"${service}":"${VULAS_RELEASE}" "${IMAGE}:latest"
+    docker push "${IMAGE}:latest"
 done


### PR DESCRIPTION
Added latest tag to docker images pushed to docker hub.
This can also be done in a more concise way, that would make distinguishing the failure between two push phases impossible:

```sh
IMAGE=${REGISTRY}/${PROJECT}/vulnerability-assessment-tool-${service}

docker tag vulnerability-assessment-tool-"${service}":"${VULAS_RELEASE}" "${IMAGE}:latest" vulnerability-assessment-tool-"${service}":"${VULAS_RELEASE}" "${IMAGE}:${VULAS_RELEASE}"
docker push "${IMAGE}:${VULAS_RELEASE}"
```

#### `TODO`s

- [ ] Tests
- [ ] Documentation