### PR TITLE
Added new endpoint to refresh the cached CVE data of a single bug

### DIFF
--- a/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/BugControllerTest.java
+++ b/rest-backend/src/test/java/com/sap/psr/vulas/backend/rest/BugControllerTest.java
@@ -188,11 +188,14 @@ public class BugControllerTest {
     	assertFalse(cve.getSummary().equals(b1.getDescription()));
 
     	// Update cache with correct data from mockup service
-    	this.bugRepository.updateCachedCveData(b1, true);
+    	//this.bugRepository.updateCachedCveData(b1, true);
+    	mockMvc.perform(post("/cves/refreshCache/"
+                + id))
+                .andExpect(status().isOk());
     	
     	// Check whether the descr has been updated
     	final Bug b2 = this.bugRepository.findByBugId("CVE-2019-17531").get(0);
-    	assertTrue(cve.getSummary().equals(b1.getDescription()));
+    	assertTrue(cve.getSummary().equals(b2.getDescription()));
     }
     
     /**


### PR DESCRIPTION
Added new endpoint `/cves/refreshCache/{id}` to update the cached CVE data of a single bug.

- [x] Tests
- [ ] Documentation